### PR TITLE
Fixed requests not being able to be completed

### DIFF
--- a/lib/_included_packages/plexnet/asyncadapter.py
+++ b/lib/_included_packages/plexnet/asyncadapter.py
@@ -235,7 +235,7 @@ pool_classes_by_scheme = {
 
 
 class AsyncPoolManager(PoolManager):
-    def _new_pool(self, scheme, host, port):
+    def _new_pool(self, scheme, host, port, request_context=None):
         """
         Create a new :class:`ConnectionPool` based on host, port and scheme.
 


### PR DESCRIPTION
When opening the Plex add-on it hung on the loading screen for a while and then went to the home screen saying no servers could be found. I looked at the kodi.log file and found the error below, and it looks like adding the new keyword argument 'request_context' to _new_pool fixed the problem.  

NOTICE: script.plex: API: ERROR: Request failed https://plex.tv/users/sign_in.xml?X-Plex-Token=**** - _new_pool() got an unexpected keyword argument 'request_context'