### PR TITLE
Kiosk mode fix when profile switching is enabled

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -13,7 +13,7 @@
     <extension point="xbmc.python.pluginsource" library="plugin.py">
         <provides>executable</provides>
     </extension>
-    <extension point="xbmc.service" library="service.py" start="startup"></extension>
+    <extension point="xbmc.service" library="service.py" start="login"></extension>
     <extension point="xbmc.addon.metadata">
         <summary lang="en">Plex for Kodi</summary>
         <summary lang="de">Plex für Kodi</summary>


### PR DESCRIPTION
This loads the background service, that auto-launches the Plex addon after profile login, not Kodi startup.

This way autostart works with multi profile setups as well.