### PR TITLE
fully fix #90

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -327,6 +327,26 @@ def timeInDayLocalSeconds():
     return int(time.time() - sod)
 
 
+def get24hFormat():
+    """
+    This takes the 24h setting from Kodi and tries to determine whether the user wants the 24h or 12h time format.
+    :return:
+    """
+    try:
+        use_24h = rpc.Settings.GetSettingValue(setting="locale.use24hourclock")["value"]
+    except:
+        return
+
+    if use_24h == "regional":
+        return "M" not in xbmc.getInfoLabel('System.Time')
+    elif use_24h == "24hours":
+        return True
+    return False
+
+
+time_format_twentyfour = get24hFormat()
+
+
 CRON = None
 
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -327,24 +327,7 @@ def timeInDayLocalSeconds():
     return int(time.time() - sod)
 
 
-def get24hFormat():
-    """
-    This takes the 24h setting from Kodi and tries to determine whether the user wants the 24h or 12h time format.
-    :return:
-    """
-    try:
-        use_24h = rpc.Settings.GetSettingValue(setting="locale.use24hourclock")["value"]
-    except:
-        return
-
-    if use_24h == "regional":
-        return "M" not in xbmc.getInfoLabel('System.Time')
-    elif use_24h == "24hours":
-        return True
-    return False
-
-
-time_format_twentyfour = get24hFormat()
+time_format_twentyfour = "M" not in xbmc.getInfoLabel('System.Time')
 
 
 CRON = None

--- a/lib/util.py
+++ b/lib/util.py
@@ -327,7 +327,24 @@ def timeInDayLocalSeconds():
     return int(time.time() - sod)
 
 
-time_format_twentyfour = "M" not in xbmc.getInfoLabel('System.Time')
+def get24hFormat():
+    """
+    This takes the 24h setting from Kodi and tries to determine whether the user wants the 24h or 12h time format.
+    :return:
+    """
+    try:
+        use_24h = rpc.Settings.GetSettingValue(setting="locale.use24hourclock")["value"]
+    except:
+        return
+
+    if use_24h == "regional":
+        return "M" not in unicode(xbmc.getInfoLabel('System.Time')).upper()
+    elif use_24h == "24hours":
+        return True
+    return False
+
+
+time_format_twentyfour = get24hFormat()
 
 
 CRON = None

--- a/lib/util.py
+++ b/lib/util.py
@@ -335,6 +335,7 @@ def get24hFormat():
     try:
         use_24h = rpc.Settings.GetSettingValue(setting="locale.use24hourclock")["value"]
     except:
+        ERROR()
         return
 
     if use_24h == "regional":

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -470,7 +470,11 @@ class SeekDialog(kodigui.BaseDialog):
         to = self.trueOffset()
         self.setProperty('time.current', util.timeDisplay(to))
         self.setProperty('time.left', util.timeDisplay(self.duration - to))
-        self.setProperty('time.end', time.strftime('%I:%M %p', time.localtime(time.time() + ((self.duration - to) / 1000))).lstrip('0'))
+
+        _fmt = '%I:%M %p'
+        if util.time_format_twentyfour:
+            _fmt = '%H:%M'
+        self.setProperty('time.end', time.strftime(_fmt, time.localtime(time.time() + ((self.duration - to) / 1000))).lstrip('0'))
 
     def seekForward(self, offset):
         self.selectedOffset += offset


### PR DESCRIPTION
Fixes the displayed end-time of a video to be properly formatted in the user's chosen 24/12h time format, based on Kodi settings.