### PR TITLE
Seeking, OSD-Autohide

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -304,6 +304,10 @@ class SeekPlayerHandler(BasePlayerHandler):
 
     def onPlayBackResumed(self):
         self.updateNowPlaying()
+        if self.dialog:
+            self.dialog.onPlaybackResumed()
+
+            util.CRON.forceTick()
         # self.hideOSD()
 
     def onPlayBackStopped(self):
@@ -338,6 +342,8 @@ class SeekPlayerHandler(BasePlayerHandler):
 
     def onPlayBackPaused(self):
         self.updateNowPlaying()
+        if self.dialog:
+            self.dialog.onPlaybackPaused()
 
     def onPlayBackSeek(self, stime, offset):
         if self.seekOnStart:

--- a/lib/player.py
+++ b/lib/player.py
@@ -285,7 +285,7 @@ class SeekPlayerHandler(BasePlayerHandler):
 
     def seekAbsolute(self, seek=None):
         self.seekOnStart = seek or self.seekOnStart
-        if self.seekOnStart:
+        if self.seekOnStart is not None:
             self.player.control('play')
             seekSeconds = self.seekOnStart / 1000.0
             try:

--- a/lib/util.py
+++ b/lib/util.py
@@ -354,6 +354,16 @@ def get24hFormat():
 time_format_twentyfour = get24hFormat()
 
 
+def getKodiSkipSteps():
+    try:
+        return rpc.Settings.GetSettingValue(setting="videoplayer.seeksteps")["value"]
+    except:
+        return
+
+
+kodiSkipSteps = getKodiSkipSteps()
+
+
 CRON = None
 
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -486,7 +486,7 @@ class AdvancedSettings(object):
     _proxiedSettings = (
         ("debug", False),
         ("kodi_skip_stepping", False),
-        ("auto_seek", False),
+        ("auto_seek", True),
         ("dynamic_timeline_seek", False),
     )
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -485,6 +485,7 @@ class AdvancedSettings(object):
 
     _proxiedSettings = (
         ("debug", False),
+        ("kodi_skip_stepping", False),
     )
 
     def __init__(self):

--- a/lib/util.py
+++ b/lib/util.py
@@ -486,6 +486,8 @@ class AdvancedSettings(object):
     _proxiedSettings = (
         ("debug", False),
         ("kodi_skip_stepping", False),
+        ("auto_seek", False),
+        ("dynamic_timeline_seek", False),
     )
 
     def __init__(self):

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -538,6 +538,8 @@ class SeekDialog(kodigui.BaseDialog):
         self.selectedOffset += offset
         if self.selectedOffset > self.duration:
             self.selectedOffset = self.duration
+        elif self.selectedOffset < 0:
+            self.selectedOffset = 0
 
         self.updateProgress()
         self.setBigSeekShift()

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -171,7 +171,7 @@ class SeekDialog(kodigui.BaseDialog):
                 if action == xbmcgui.ACTION_MOUSE_MOVE:
                     return self.seekMouse(action)
                 elif action in (xbmcgui.ACTION_MOVE_RIGHT, xbmcgui.ACTION_STEP_FORWARD):
-                    return self.seekForward(30000)
+                    return self.seekForward(10000)
                 elif action in (xbmcgui.ACTION_MOVE_LEFT, xbmcgui.ACTION_STEP_BACK):
                     return self.seekBack(10000)
                 elif action == xbmcgui.ACTION_MOVE_DOWN:
@@ -182,9 +182,15 @@ class SeekDialog(kodigui.BaseDialog):
                 #     self.seekBack(60000)
             elif controlID == self.NO_OSD_BUTTON_ID:
                 if action in (xbmcgui.ACTION_MOVE_RIGHT, xbmcgui.ACTION_MOVE_LEFT):
-                    self.showOSD()
-                    self.setFocusId(self.MAIN_BUTTON_ID)
-                elif action in (
+                    if action == xbmcgui.ACTION_MOVE_RIGHT:
+                        self.seekForward(30000)
+
+                    else:
+                        self.seekBack(10000)
+                    return
+                #     self.showOSD()
+                #     self.setFocusId(self.MAIN_BUTTON_ID)
+                if action in (
                     xbmcgui.ACTION_MOVE_UP,
                     xbmcgui.ACTION_MOVE_DOWN,
                     xbmcgui.ACTION_BIG_STEP_FORWARD,

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -173,7 +173,7 @@ class SeekDialog(kodigui.BaseDialog):
                 elif action in (xbmcgui.ACTION_MOVE_RIGHT, xbmcgui.ACTION_STEP_FORWARD):
                     return self.seekForward(30000)
                 elif action in (xbmcgui.ACTION_MOVE_LEFT, xbmcgui.ACTION_STEP_BACK):
-                    return self.seekBack(15000)
+                    return self.seekBack(10000)
                 elif action == xbmcgui.ACTION_MOVE_DOWN:
                     self.updateBigSeek()
                 # elif action == xbmcgui.ACTION_MOVE_UP:
@@ -291,7 +291,7 @@ class SeekDialog(kodigui.BaseDialog):
         self.delayedSeek()
 
     def skipBack(self):
-        self.seekBack(15000)
+        self.seekBack(10000)
         self.delayedSeek()
 
     def delayedSeek(self):

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -98,7 +98,7 @@ class SeekDialog(kodigui.BaseDialog):
         self._atSkipStep = -1
         self._lastSkipDirection = None
         self.skipSteps = self.SKIP_STEPS
-        self.useKodiSkipSteps = False
+        self.useKodiSkipSteps = util.getSetting('kodi_skip_stepping', False)
 
         if self.useKodiSkipSteps:
             self.skipSteps = {"negative": [], "positive": []}

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -184,9 +184,9 @@ class SeekDialog(kodigui.BaseDialog):
                 if action == xbmcgui.ACTION_MOUSE_MOVE:
                     return self.seekMouse(action)
                 elif action in (xbmcgui.ACTION_MOVE_RIGHT, xbmcgui.ACTION_STEP_FORWARD):
-                    return self.seekEitherDirection(10000, autoSeek=True)
+                    return self.seekEitherDirection(10000, auto_seek=True)
                 elif action in (xbmcgui.ACTION_MOVE_LEFT, xbmcgui.ACTION_STEP_BACK):
-                    return self.seekEitherDirection(-10000, autoSeek=True)
+                    return self.seekEitherDirection(-10000, auto_seek=True)
                 elif action == xbmcgui.ACTION_MOVE_DOWN:
                     self.updateBigSeek()
                 # elif action == xbmcgui.ACTION_MOVE_UP:
@@ -534,7 +534,7 @@ class SeekDialog(kodigui.BaseDialog):
         if state_before_seek == self.player.STATE_PAUSED:
             self.player.control("pause")
 
-    def seekEitherDirection(self, offset, autoSeek=False):
+    def seekEitherDirection(self, offset, auto_seek=False):
         self.selectedOffset += offset
         if self.selectedOffset > self.duration:
             self.selectedOffset = self.duration
@@ -543,7 +543,7 @@ class SeekDialog(kodigui.BaseDialog):
 
         self.updateProgress()
         self.setBigSeekShift()
-        if autoSeek:
+        if auto_seek:
             self.resetAutoSeekTimer()
         self.bigSeekHideTimer.reset()
 

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -604,6 +604,9 @@ class SeekDialog(kodigui.BaseDialog):
 
         ratio = self.selectedOffset / float(self.duration)
         w = int(ratio * self.SEEK_IMAGE_WIDTH)
+
+        current_w = int(self.offset / float(self.duration) * self.SEEK_IMAGE_WIDTH)
+
         bifx = (w - int(ratio * 324)) + self.BAR_X
         # bifx = w
         self.selectionIndicator.setPosition(w, 896)
@@ -618,19 +621,17 @@ class SeekDialog(kodigui.BaseDialog):
             self.setProperty('bif.image', self.handler.player.playerObject.getBifUrl(self.selectedOffset))
             self.bifImageControl.setPosition(bifx, 752)
 
-        self.seekbarControl.setWidth(w)
-
         # current seek position below current offset?
         if self.selectedOffset < self.offset:
             self.positionControl.setWidth(w)
+            self.seekbarControl.setWidth(current_w)
 
         # current seek position ahead of current offset
         # (we may have "shortened" the width before, by seeking negatively)
         elif self.selectedOffset > self.offset:
-            ratio = self.offset / float(self.duration)
-            w = int(ratio * self.SEEK_IMAGE_WIDTH)
-            if self.positionControl.getWidth() < w:
-                self.positionControl.setWidth(w)
+            self.seekbarControl.setWidth(w)
+            if self.positionControl.getWidth() < current_w:
+                self.positionControl.setWidth(current_w)
 
     def onPlaybackResumed(self):
         self._osdHideFast = True

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -302,7 +302,7 @@ class SeekDialog(kodigui.BaseDialog):
 
     def delayedSeek(self):
         self.setProperty('button.seek', '1')
-        self._delayedSeekTimeout = time.time() + 0.5
+        self._delayedSeekTimeout = time.time() + 1.0
 
         if not self._delayedSeekThread or not self._delayedSeekThread.isAlive():
             self._delayedSeekThread = threading.Thread(target=self._delayedSeek)

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -345,7 +345,6 @@ class SeekDialog(kodigui.BaseDialog):
 
             if not xbmc.abortRequested:
                 self._lastSkipDirection = None
-                self._seeking = False
                 self.doSeek()
         finally:
             self.setProperty('button.seek', '')
@@ -530,6 +529,7 @@ class SeekDialog(kodigui.BaseDialog):
         self.setProperty('time.end', time.strftime(_fmt, time.localtime(time.time() + ((self.duration - to) / 1000))).lstrip('0'))
 
     def doSeek(self, offset=None, settings_changed=False):
+        self._seeking = False
         state_before_seek = self.player.playState
         self.handler.seek(self.selectedOffset if offset is None else offset, settings_changed=settings_changed)
 

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -90,13 +90,21 @@ class SeekDialog(kodigui.BaseDialog):
         self._delayedSeekThread = None
         self._delayedSeekTimeout = 0
         self._osd_hide_fast = False
+        self._hide_delay = self.HIDE_DELAY
+
+        try:
+            seconds = int(xbmc.getInfoLabel("Skin.String(SkinHelper.AutoCloseVideoOSD)"))
+            if seconds > 0:
+                self._hide_delay = seconds
+        except ValueError:
+            pass
 
     @property
     def player(self):
         return self.handler.player
 
     def resetTimeout(self):
-        self.timeout = time.time() + self.HIDE_DELAY
+        self.timeout = time.time() + self._hide_delay
 
     def trueOffset(self):
         if self.handler.mode == self.handler.MODE_ABSOLUTE:

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -184,9 +184,9 @@ class SeekDialog(kodigui.BaseDialog):
                 if action == xbmcgui.ACTION_MOUSE_MOVE:
                     return self.seekMouse(action)
                 elif action in (xbmcgui.ACTION_MOVE_RIGHT, xbmcgui.ACTION_STEP_FORWARD):
-                    return self.seekEitherDirection(10000, auto_seek=True)
+                    return self.seekByOffset(10000, auto_seek=True)
                 elif action in (xbmcgui.ACTION_MOVE_LEFT, xbmcgui.ACTION_STEP_BACK):
-                    return self.seekEitherDirection(-10000, auto_seek=True)
+                    return self.seekByOffset(-10000, auto_seek=True)
                 elif action == xbmcgui.ACTION_MOVE_DOWN:
                     self.updateBigSeek()
                 # elif action == xbmcgui.ACTION_MOVE_UP:
@@ -320,12 +320,12 @@ class SeekDialog(kodigui.BaseDialog):
 
     def skipForward(self):
         step = self.determineSkipStep("positive", reset=self._lastSkipDirection != "positive")
-        self.seekEitherDirection(step)
+        self.seekByOffset(step)
         self.delayedSeek()
 
     def skipBack(self):
         step = self.determineSkipStep("negative", reset=self._lastSkipDirection != "negative")
-        self.seekEitherDirection(step)
+        self.seekByOffset(step)
         self.delayedSeek()
 
     def delayedSeek(self):
@@ -534,7 +534,7 @@ class SeekDialog(kodigui.BaseDialog):
         if state_before_seek == self.player.STATE_PAUSED:
             self.player.control("pause")
 
-    def seekEitherDirection(self, offset, auto_seek=False):
+    def seekByOffset(self, offset, auto_seek=False):
         self.selectedOffset += offset
         if self.selectedOffset > self.duration:
             self.selectedOffset = self.duration

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -165,9 +165,9 @@ class SeekDialog(kodigui.BaseDialog):
                 if action == xbmcgui.ACTION_MOUSE_MOVE:
                     return self.seekMouse(action)
                 elif action in (xbmcgui.ACTION_MOVE_RIGHT, xbmcgui.ACTION_STEP_FORWARD):
-                    return self.seekForward(10000)
+                    return self.seekForward(30000)
                 elif action in (xbmcgui.ACTION_MOVE_LEFT, xbmcgui.ACTION_STEP_BACK):
-                    return self.seekBack(10000)
+                    return self.seekBack(15000)
                 elif action == xbmcgui.ACTION_MOVE_DOWN:
                     self.updateBigSeek()
                 # elif action == xbmcgui.ACTION_MOVE_UP:

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -257,6 +257,9 @@ class SeekDialog(kodigui.BaseDialog):
                 xbmc.sleep(100)
                 self.updateBigSeek()
                 self.updateProgress(set_to_current=False)
+                if self.useAutoSeek:
+                    self.delayedSeek()
+
             else:
                 self.setBigSeekShift()
                 self.updateProgress()

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -659,7 +659,7 @@ class SeekDialog(kodigui.BaseDialog):
 
     def seekMouse(self, action, without_osd=False):
         x = self.mouseXTrans(action.getAmount1())
-        y = self.mouseXTrans(action.getAmount2())
+        y = self.mouseYTrans(action.getAmount2())
         if not (self.BAR_Y <= y <= self.BAR_BOTTOM):
             return
 

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -347,6 +347,7 @@ class SeekDialog(kodigui.BaseDialog):
                 self._lastSkipDirection = None
                 self.doSeek()
         finally:
+            self._seeking = False
             self.setProperty('button.seek', '')
 
     def handleDialog(self, func):

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -806,6 +806,8 @@ class SeekDialog(kodigui.BaseDialog):
                 if not xbmc.getCondVisibility('Window.IsActive(videoosd) | Player.Rewinding | Player.Forwarding'):
                     self.hideOSD()
 
+        self._osdHideFast = False
+
         try:
             self.offset = offset or int(self.handler.player.getTime() * 1000)
         except RuntimeError:  # Playback has stopped

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -102,11 +102,10 @@ class SeekDialog(kodigui.BaseDialog):
         self._lastSkipDirection = None
         self._forcedLastSkipAmount = None
         self.skipSteps = self.SKIP_STEPS
-        self.useKodiSkipSteps = util.advancedSettings.kodiSkipStepping
         self.useAutoSeek = util.advancedSettings.autoSeek
         self.useDynamicStepsForTimeline = util.advancedSettings.dynamicTimelineSeek
 
-        if self.useKodiSkipSteps:
+        if util.kodiSkipSteps and util.advancedSettings.kodiSkipStepping:
             self.skipSteps = {"negative": [], "positive": []}
             for step in util.kodiSkipSteps:
                 key = "negative" if step < 0 else "positive"

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -103,8 +103,8 @@ class SeekDialog(kodigui.BaseDialog):
         self._forcedLastSkipAmount = None
         self.skipSteps = self.SKIP_STEPS
         self.useKodiSkipSteps = util.advancedSettings.kodiSkipStepping
-        self.useAutoSeek = util.getSetting('auto_seek', False)
-        self.useDynamicStepsForTimeline = util.getSetting('dynamic_timeline_seek', False)
+        self.useAutoSeek = util.advancedSettings.autoSeek
+        self.useDynamicStepsForTimeline = util.advancedSettings.dynamicTimelineSeek
 
         if self.useKodiSkipSteps:
             self.skipSteps = {"negative": [], "positive": []}

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -102,6 +102,7 @@ class SeekDialog(kodigui.BaseDialog):
         self._forcedLastSkipAmount = None
         self.skipSteps = self.SKIP_STEPS
         self.useKodiSkipSteps = util.advancedSettings.kodiSkipStepping
+        self.useAutoSeek = util.getSetting('auto_seek', False)
 
         if self.useKodiSkipSteps:
             self.skipSteps = {"negative": [], "positive": []}
@@ -187,9 +188,9 @@ class SeekDialog(kodigui.BaseDialog):
                 if action == xbmcgui.ACTION_MOUSE_MOVE:
                     return self.seekMouse(action)
                 elif action in (xbmcgui.ACTION_MOVE_RIGHT, xbmcgui.ACTION_STEP_FORWARD):
-                    return self.seekByOffset(10000, auto_seek=True)
+                    return self.seekByOffset(10000, auto_seek=self.useAutoSeek)
                 elif action in (xbmcgui.ACTION_MOVE_LEFT, xbmcgui.ACTION_STEP_BACK):
-                    return self.seekByOffset(-10000, auto_seek=True)
+                    return self.seekByOffset(-10000, auto_seek=self.useAutoSeek)
                 elif action == xbmcgui.ACTION_MOVE_DOWN:
                     self.updateBigSeek()
                 # elif action == xbmcgui.ACTION_MOVE_UP:
@@ -373,14 +374,20 @@ class SeekDialog(kodigui.BaseDialog):
         if step is not None:
             self.seekByOffset(step, without_osd=without_osd)
 
-        self.delayedSeek()
+        if self.useAutoSeek:
+            self.delayedSeek()
+        else:
+            self.setProperty('button.seek', '1')
 
     def skipBack(self, without_osd=False):
         step = self.determineSkipStep("negative")
         if step is not None:
             self.seekByOffset(step, without_osd=without_osd)
 
-        self.delayedSeek()
+        if self.useAutoSeek:
+            self.delayedSeek()
+        else:
+            self.setProperty('button.seek', '1')
 
     def delayedSeek(self):
         self.setProperty('button.seek', '1')
@@ -700,7 +707,7 @@ class SeekDialog(kodigui.BaseDialog):
             # (we may have "shortened" the width before, by seeking negatively)
             elif self.selectedOffset > self.offset:
                 self.seekbarControl.setWidth(w)
-                if not big_seek and self.positionControl.getWidth() < current_w:
+                if self.positionControl.getWidth() < current_w:
                     self.positionControl.setWidth(current_w)
 
             else:

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -394,7 +394,7 @@ class SeekDialog(kodigui.BaseDialog):
                 step = self.skipSteps[use_direction][min(self._atSkipStep, len(self.skipSteps[use_direction]) - 1)] * -1
 
                 # we've hit a boundary, reverse the difference of the last skip step in relation to the boundary
-                if self._forcedLastSkipAmount:
+                if self._forcedLastSkipAmount is not None:
                     step = self._forcedLastSkipAmount * -1
                     self._forcedLastSkipAmount = None
 
@@ -662,10 +662,11 @@ class SeekDialog(kodigui.BaseDialog):
         """
         self._seeking = True
         self._seekingWithoutOSD = without_osd
+        lastSelectedOffset = self.selectedOffset
         self.selectedOffset += offset
         if self.selectedOffset > self.duration:
             # offset = +100, at = 80000, duration = 80005, realoffset = 5
-            self._forcedLastSkipAmount = self.duration - self.selectedOffset
+            self._forcedLastSkipAmount = self.duration - lastSelectedOffset
             self.selectedOffset = self.duration
         elif self.selectedOffset < 0:
             # offset = -100, at = 5, realat = -95, realoffset = -100 - -95 = -5

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -98,7 +98,7 @@ class SeekDialog(kodigui.BaseDialog):
         self._atSkipStep = -1
         self._lastSkipDirection = None
         self.skipSteps = self.SKIP_STEPS
-        self.useKodiSkipSteps = util.getSetting('kodi_skip_stepping', False)
+        self.useKodiSkipSteps = util.advancedSettings.kodiSkipStepping
 
         if self.useKodiSkipSteps:
             self.skipSteps = {"negative": [], "positive": []}

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -581,10 +581,13 @@ class SeekDialog(kodigui.BaseDialog):
         self.bigSeekControl.reset()
         self.bigSeekControl.addItems(items)
 
-    def updateCurrent(self):
+    def updateCurrent(self, update_position_control=True):
         ratio = self.trueOffset() / float(self.duration)
-        w = int(ratio * self.SEEK_IMAGE_WIDTH)
-        self.positionControl.setWidth(w)
+
+        if update_position_control:
+            w = int(ratio * self.SEEK_IMAGE_WIDTH)
+            self.positionControl.setWidth(w)
+
         to = self.trueOffset()
         self.setProperty('time.current', util.timeDisplay(to))
         self.setProperty('time.left', util.timeDisplay(self.duration - to))
@@ -751,8 +754,7 @@ class SeekDialog(kodigui.BaseDialog):
             self.doSeek()
             return
 
-        if not self._seeking:
-            self.updateCurrent()
+        self.updateCurrent(update_position_control=not self._seeking)
 
     def showPlaylistDialog(self):
         if not self.playlistDialog:

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -763,7 +763,6 @@ class SeekDialog(kodigui.BaseDialog):
         if set_to_current:
             self.seekbarControl.setWidth(w)
             self.positionControl.setWidth(w)
-
         else:
             # we're seeking
 

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -252,7 +252,7 @@ class SeekDialog(kodigui.BaseDialog):
     def onClick(self, controlID):
         if controlID == self.MAIN_BUTTON_ID:
             self.resetAutoSeekTimer(None)
-            self.handler.seek(self.selectedOffset)
+            self.doSeek()
         elif controlID == self.NO_OSD_BUTTON_ID:
             self.showOSD()
         elif controlID == self.SETTINGS_BUTTON_ID:
@@ -315,7 +315,7 @@ class SeekDialog(kodigui.BaseDialog):
                     break
 
             if not xbmc.abortRequested:
-                self.handler.seek(self.selectedOffset)
+                self.doSeek()
         finally:
             self.setProperty('button.seek', '')
 
@@ -425,7 +425,7 @@ class SeekDialog(kodigui.BaseDialog):
         if changed == 'SUBTITLE':
             self.handler.setSubtitles()
         elif changed:
-            self.handler.seek(self.trueOffset(), settings_changed=True)
+            self.doSeek(self.trueOffset(), settings_changed=True)
 
     def setBigSeekShift(self):
         closest = None
@@ -497,6 +497,13 @@ class SeekDialog(kodigui.BaseDialog):
         if util.time_format_twentyfour:
             _fmt = '%H:%M'
         self.setProperty('time.end', time.strftime(_fmt, time.localtime(time.time() + ((self.duration - to) / 1000))).lstrip('0'))
+
+    def doSeek(self, offset=None, settings_changed=False):
+        state_before_seek = self.player.playState
+        self.handler.seek(self.selectedOffset if offset is None else offset, settings_changed=settings_changed)
+
+        if state_before_seek == self.player.STATE_PAUSED:
+            self.player.control("pause")
 
     def seekForward(self, offset, autoSeek=False):
         self.selectedOffset += offset
@@ -624,7 +631,7 @@ class SeekDialog(kodigui.BaseDialog):
 
         if self.autoSeekTimeout and time.time() > self.autoSeekTimeout and self.offset != self.selectedOffset:
             self.resetAutoSeekTimer(None)
-            self.handler.seek(self.selectedOffset)
+            self.doSeek()
 
         self.updateCurrent()
 

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -104,6 +104,7 @@ class SeekDialog(kodigui.BaseDialog):
         self.skipSteps = self.SKIP_STEPS
         self.useKodiSkipSteps = util.advancedSettings.kodiSkipStepping
         self.useAutoSeek = util.getSetting('auto_seek', False)
+        self.useDynamicStepsForTimeline = util.getSetting('dynamic_timeline_seek', False)
 
         if self.useKodiSkipSteps:
             self.skipSteps = {"negative": [], "positive": []}
@@ -206,9 +207,15 @@ class SeekDialog(kodigui.BaseDialog):
                 # we're seeking from the timeline with the OSD open - do an actual timeline seek
 
                 if action in (xbmcgui.ACTION_MOVE_RIGHT, xbmcgui.ACTION_STEP_FORWARD):
+                    if self.useDynamicStepsForTimeline:
+                        return self.skipForward()
                     return self.seekByOffset(10000, auto_seek=self.useAutoSeek)
+
                 elif action in (xbmcgui.ACTION_MOVE_LEFT, xbmcgui.ACTION_STEP_BACK):
+                    if self.useDynamicStepsForTimeline:
+                        return self.skipBack()
                     return self.seekByOffset(-10000, auto_seek=self.useAutoSeek)
+
                 elif action == xbmcgui.ACTION_MOVE_DOWN:
                     self.updateBigSeek()
                 # elif action == xbmcgui.ACTION_MOVE_UP:

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -85,20 +85,20 @@ class SeekDialog(kodigui.BaseDialog):
         self.initialized = False
         self.playlistDialog = None
         self.timeout = None
-        self.auto_seek_timeout = None
+        self.autoSeekTimeout = None
         self.hasDialog = False
         self.lastFocusID = None
         self.playlistDialogVisible = False
         self._delayedSeekThread = None
         self._delayedSeekTimeout = 0
-        self._osd_hide_fast = False
-        self._hide_delay = self.HIDE_DELAY
-        self._auto_seek_delay = self.AUTO_SEEK_DELAY
+        self._osdHideFast = False
+        self._hideDelay = self.HIDE_DELAY
+        self._autoSeekDelay = self.AUTO_SEEK_DELAY
 
         try:
             seconds = int(xbmc.getInfoLabel("Skin.String(SkinHelper.AutoCloseVideoOSD)"))
             if seconds > 0:
-                self._hide_delay = seconds
+                self._hideDelay = seconds
         except ValueError:
             pass
 
@@ -107,10 +107,10 @@ class SeekDialog(kodigui.BaseDialog):
         return self.handler.player
 
     def resetTimeout(self):
-        self.timeout = time.time() + self._hide_delay
+        self.timeout = time.time() + self._hideDelay
 
     def resetAutoSeekTimer(self, value="not_set"):
-        self.auto_seek_timeout = value if value != "not_set" else time.time() + self._auto_seek_delay
+        self.autoSeekTimeout = value if value != "not_set" else time.time() + self._autoSeekDelay
 
     def trueOffset(self):
         if self.handler.mode == self.handler.MODE_ABSOLUTE:
@@ -171,9 +171,9 @@ class SeekDialog(kodigui.BaseDialog):
                 if action == xbmcgui.ACTION_MOUSE_MOVE:
                     return self.seekMouse(action)
                 elif action in (xbmcgui.ACTION_MOVE_RIGHT, xbmcgui.ACTION_STEP_FORWARD):
-                    return self.seekForward(10000)
+                    return self.seekForward(10000, autoSeek=True)
                 elif action in (xbmcgui.ACTION_MOVE_LEFT, xbmcgui.ACTION_STEP_BACK):
-                    return self.seekBack(10000)
+                    return self.seekBack(10000, autoSeek=True)
                 elif action == xbmcgui.ACTION_MOVE_DOWN:
                     self.updateBigSeek()
                 # elif action == xbmcgui.ACTION_MOVE_UP:
@@ -182,14 +182,14 @@ class SeekDialog(kodigui.BaseDialog):
                 #     self.seekBack(60000)
             elif controlID == self.NO_OSD_BUTTON_ID:
                 if action in (xbmcgui.ACTION_MOVE_RIGHT, xbmcgui.ACTION_MOVE_LEFT):
+                    if not self.selectedOffset:
+                        self.selectedOffset = self.trueOffset()
+
                     if action == xbmcgui.ACTION_MOVE_RIGHT:
-                        self.seekForward(30000)
+                        self.skipForward()
 
                     else:
-                        self.seekBack(10000)
-                    return
-                #     self.showOSD()
-                #     self.setFocusId(self.MAIN_BUTTON_ID)
+                        self.skipBack()
                 if action in (
                     xbmcgui.ACTION_MOVE_UP,
                     xbmcgui.ACTION_MOVE_DOWN,
@@ -498,24 +498,26 @@ class SeekDialog(kodigui.BaseDialog):
             _fmt = '%H:%M'
         self.setProperty('time.end', time.strftime(_fmt, time.localtime(time.time() + ((self.duration - to) / 1000))).lstrip('0'))
 
-    def seekForward(self, offset):
+    def seekForward(self, offset, autoSeek=False):
         self.selectedOffset += offset
         if self.selectedOffset > self.duration:
             self.selectedOffset = self.duration
 
         self.updateProgress()
         self.setBigSeekShift()
-        self.resetAutoSeekTimer()
+        if autoSeek:
+            self.resetAutoSeekTimer()
         self.bigSeekHideTimer.reset()
 
-    def seekBack(self, offset):
+    def seekBack(self, offset, autoSeek=False):
         self.selectedOffset -= offset
         if self.selectedOffset < 0:
             self.selectedOffset = 0
 
         self.updateProgress()
         self.setBigSeekShift()
-        self.resetAutoSeekTimer()
+        if autoSeek:
+            self.resetAutoSeekTimer()
         self.bigSeekHideTimer.reset()
 
     def seekMouse(self, action):
@@ -589,11 +591,11 @@ class SeekDialog(kodigui.BaseDialog):
         self.seekbarControl.setWidth(w)
 
     def onPlaybackResumed(self):
-        self._osd_hide_fast = True
+        self._osdHideFast = True
         self.tick()
 
     def onPlaybackPaused(self):
-        self._osd_hide_fast = False
+        self._osdHideFast = False
 
     def tick(self, offset=None):
         if not self.initialized:
@@ -609,20 +611,20 @@ class SeekDialog(kodigui.BaseDialog):
                     self.hideOSD()
 
             # try insta-hiding the OSDs when playback was requested
-            elif self._osd_hide_fast:
+            elif self._osdHideFast:
                 xbmc.executebuiltin('Dialog.Close(videoosd,true)')
                 xbmc.executebuiltin('Dialog.Close(seekbar,true)')
                 if not xbmc.getCondVisibility('Window.IsActive(videoosd) | Player.Rewinding | Player.Forwarding'):
                     self.hideOSD()
 
-        if self.auto_seek_timeout and time.time() > self.auto_seek_timeout:
-            self.resetAutoSeekTimer(None)
-            self.handler.seek(self.selectedOffset)
-
         try:
             self.offset = offset or int(self.handler.player.getTime() * 1000)
         except RuntimeError:  # Playback has stopped
             return
+
+        if self.autoSeekTimeout and time.time() > self.autoSeekTimeout and self.offset != self.selectedOffset:
+            self.resetAutoSeekTimer(None)
+            self.handler.seek(self.selectedOffset)
 
         self.updateCurrent()
 
@@ -648,7 +650,7 @@ class SeekDialog(kodigui.BaseDialog):
     def hideOSD(self):
         self.setProperty('show.OSD', '')
         self.setFocusId(self.NO_OSD_BUTTON_ID)
-        self._osd_hide_fast = False
+        self._osdHideFast = False
         if self.playlistDialog:
             self.playlistDialog.doClose()
             self.playlistDialogVisible = False

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -348,7 +348,7 @@ class SeekDialog(kodigui.BaseDialog):
                 use_direction = self._lastSkipDirection
 
                 # use the inverse value of the current skip step
-                step = self.skipSteps[use_direction][self._atSkipStep] * -1
+                step = self.skipSteps[use_direction][min(self._atSkipStep, len(self.skipSteps[use_direction]) - 1)] * -1
 
                 # we've hit a boundary, reverse the difference of the last skip step in relation to the boundary
                 if self._forcedLastSkipAmount:
@@ -360,8 +360,8 @@ class SeekDialog(kodigui.BaseDialog):
         else:
             # no reversal of any kind was requested and we've not hit any boundary, use the next skip step
             if self._forcedLastSkipAmount is None:
-                self._atSkipStep = min([self._atSkipStep + 1, stepCount - 1])
-                step = self.skipSteps[use_direction][self._atSkipStep]
+                self._atSkipStep += 1
+                step = self.skipSteps[use_direction][min(self._atSkipStep, stepCount - 1)]
 
             else:
                 # we've hit a timeline boundary and haven't reversed yet. Don't do any further skipping

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -951,3 +951,10 @@ msgctxt "#32463"
 msgid "By Artist"
 msgstr ""
 
+msgctxt "#32464"
+msgid "Player"
+msgstr ""
+
+msgctxt "#32465"
+msgid "Use skip step settings from Kodi"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -962,3 +962,7 @@ msgstr ""
 msgctxt "#32466"
 msgid "Automatically seek selected position after a delay"
 msgstr ""
+
+msgctxt "#32471"
+msgid "Use Plex/Kodi steps for timeline as well"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -958,3 +958,7 @@ msgstr ""
 msgctxt "#32465"
 msgid "Use skip step settings from Kodi"
 msgstr ""
+
+msgctxt "#32466"
+msgid "Automatically seek to the selected timeline position after a second"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -964,5 +964,5 @@ msgid "Automatically seek selected position after a delay"
 msgstr ""
 
 msgctxt "#32471"
-msgid "Use Plex/Kodi steps for timeline as well"
+msgid "Use Plex/Kodi steps for timeline"
 msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -960,5 +960,5 @@ msgid "Use skip step settings from Kodi"
 msgstr ""
 
 msgctxt "#32466"
-msgid "Automatically seek to the selected timeline position after a second"
+msgid "Automatically seek selected position after a delay"
 msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -949,3 +949,11 @@ msgstr "Künstler(in)"
 msgctxt "#32463"
 msgid "By Artist"
 msgstr "Nach Künstler(in)"
+
+msgctxt "#32464"
+msgid "Player"
+msgstr "Wiedergabe"
+
+msgctxt "#32465"
+msgid "Use skip step settings from Kodi"
+msgstr "Skip-Schritte-Einstellung von Kodi benutzen"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -961,3 +961,7 @@ msgstr "Skip-Schritte-Einstellung von Kodi benutzen"
 msgctxt "#32466"
 msgid "Automatically seek to the selected timeline position after a second"
 msgstr "Nach Verzögerung automatisch zur aktuell gewählten Position springen"
+
+msgctxt "#32471"
+msgid "Plex/Kodi-Skip-Schritte auch für die Zeitachse verwenden"
+msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -963,5 +963,5 @@ msgid "Automatically seek to the selected timeline position after a second"
 msgstr "Nach Verzögerung automatisch zur aktuell gewählten Position springen"
 
 msgctxt "#32471"
-msgid "Plex/Kodi-Skip-Schritte auch für die Zeitachse verwenden"
-msgstr ""
+msgid "Use Plex/Kodi steps for timeline"
+msgstr "Plex/Kodi-Skip-Schritte für die Zeitachse verwenden"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -957,3 +957,7 @@ msgstr "Wiedergabe"
 msgctxt "#32465"
 msgid "Use skip step settings from Kodi"
 msgstr "Skip-Schritte-Einstellung von Kodi benutzen"
+
+msgctxt "#32466"
+msgid "Automatically seek to the selected timeline position after a second"
+msgstr "Nach einer Sekunde automatisch zur aktuell gewählten Position auf der Zeitachse springen"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -960,4 +960,4 @@ msgstr "Skip-Schritte-Einstellung von Kodi benutzen"
 
 msgctxt "#32466"
 msgid "Automatically seek to the selected timeline position after a second"
-msgstr "Nach einer Sekunde automatisch zur aktuell gewählten Position auf der Zeitachse springen"
+msgstr "Nach Verzögerung automatisch zur aktuell gewählten Position springen"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -8,5 +8,7 @@
     <!-- <setting id="playback_directplay_force" type="bool" label="32027" default="false" enable="eq(-1,true)" subsetting="true" /> -->
     <setting id="debug" type="bool" label="32024" default="false" />
   </category>
-
+  <category label="32464">
+    <setting id="kodi_skip_stepping" type="bool" label="32465" default="false" />
+  </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,6 +9,7 @@
     <setting id="debug" type="bool" label="32024" default="false" />
   </category>
   <category label="32464">
+    <setting id="auto_seek" type="bool" label="32466" default="false" />
     <setting id="kodi_skip_stepping" type="bool" label="32465" default="false" />
   </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -11,5 +11,6 @@
   <category label="32464">
     <setting id="auto_seek" type="bool" label="32466" default="false" />
     <setting id="kodi_skip_stepping" type="bool" label="32465" default="false" />
+    <setting id="dynamic_timeline_seek" type="bool" label="32471" default="false" />
   </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,7 +9,7 @@
     <setting id="debug" type="bool" label="32024" default="false" />
   </category>
   <category label="32464">
-    <setting id="auto_seek" type="bool" label="32466" default="false" />
+    <setting id="auto_seek" type="bool" label="32466" default="true" />
     <setting id="kodi_skip_stepping" type="bool" label="32465" default="false" />
     <setting id="dynamic_timeline_seek" type="bool" label="32471" default="false" />
   </category>

--- a/resources/skins/Main/1080i/script-plex-seek_dialog.xml
+++ b/resources/skins/Main/1080i/script-plex-seek_dialog.xml
@@ -20,7 +20,7 @@
             <onclick>SetProperty(show.OSD,1)</onclick>
         </control>
         <control type="group" id="802">
-            <visible>[!String.IsEmpty(Window.Property(show.OSD)) | Window.IsVisible(seekbar)] + !Window.IsVisible(osdvideosettings) + !Window.IsVisible(osdaudiosettings) + !Window.IsVisible(subtitlesearch) + !Window.IsActive(playerprocessinfo)</visible>
+            <visible>[!String.IsEmpty(Window.Property(show.OSD)) | Window.IsVisible(seekbar) | !String.IsEmpty(Window.Property(button.seek))] + !Window.IsVisible(osdvideosettings) + !Window.IsVisible(osdaudiosettings) + !Window.IsVisible(subtitlesearch) + !Window.IsActive(playerprocessinfo)</visible>
             <animation effect="fade" time="200" delay="200" end="0">Hidden</animation>
             <control type="group">
                 <visible>String.IsEmpty(Window.Property(settings.visible)) + [Window.IsVisible(seekbar) | Window.IsVisible(videoosd) | Player.ShowInfo]</visible>
@@ -613,44 +613,43 @@
                     </focusedlayout>
                 </control>
             </control>
-
-            <control type="group" id="202">
-                <visible>Control.HasFocus(100) | Control.HasFocus(501) | !String.IsEmpty(Window.Property(button.seek))</visible>
-                <posx>0</posx>
-                <posy>896</posy>
-                <control type="group" id="203">
-                    <posx>-50</posx>
-                    <posy>0</posy>
-                    <control type="image">
-                        <animation effect="fade" time="100" delay="100" end="100">Visible</animation>
-                        <posx>0</posx>
-                        <posy>0</posy>
-                        <width>101</width>
-                        <height>39</height>
-                        <texture>script.plex/indicators/player-selection-time_box.png</texture>
-                        <colordiffuse>D0000000</colordiffuse>
-                    </control>
-                    <control type="label">
-                        <posx>0</posx>
-                        <posy>0</posy>
-                        <width>101</width>
-                        <height>40</height>
-                        <font>font10</font>
-                        <align>center</align>
-                        <aligny>center</aligny>
-                        <textcolor>FFFFFFFF</textcolor>
-                        <label>$INFO[Window.Property(time.selection)]</label>
-                    </control>
-                </control>
+        </control>
+        <control type="group" id="202">
+            <visible>Control.HasFocus(100) | Control.HasFocus(501) | !String.IsEmpty(Window.Property(button.seek))</visible>
+            <posx>0</posx>
+            <posy>896</posy>
+            <control type="group" id="203">
+                <posx>-50</posx>
+                <posy>0</posy>
                 <control type="image">
                     <animation effect="fade" time="100" delay="100" end="100">Visible</animation>
-                    <posx>-6</posx>
-                    <posy>39</posy>
-                    <width>15</width>
-                    <height>7</height>
-                    <texture>script.plex/indicators/player-selection-time_arrow.png</texture>
+                    <posx>0</posx>
+                    <posy>0</posy>
+                    <width>101</width>
+                    <height>39</height>
+                    <texture>script.plex/indicators/player-selection-time_box.png</texture>
                     <colordiffuse>D0000000</colordiffuse>
                 </control>
+                <control type="label">
+                    <posx>0</posx>
+                    <posy>0</posy>
+                    <width>101</width>
+                    <height>40</height>
+                    <font>font10</font>
+                    <align>center</align>
+                    <aligny>center</aligny>
+                    <textcolor>FFFFFFFF</textcolor>
+                    <label>$INFO[Window.Property(time.selection)]</label>
+                </control>
+            </control>
+            <control type="image">
+                <animation effect="fade" time="100" delay="100" end="100">Visible</animation>
+                <posx>-6</posx>
+                <posy>39</posy>
+                <width>15</width>
+                <height>7</height>
+                <texture>script.plex/indicators/player-selection-time_arrow.png</texture>
+                <colordiffuse>D0000000</colordiffuse>
             </control>
         </control>
     </controls>

--- a/resources/skins/Main/1080i/script-plex-seek_dialog.xml
+++ b/resources/skins/Main/1080i/script-plex-seek_dialog.xml
@@ -17,7 +17,7 @@
             <texturefocus>-</texturefocus>
             <texturenofocus>-</texturenofocus>
             <label> </label>
-            <onclick>SetProperty(show.OSD,1)</onclick>
+            <onclick condition="String.IsEmpty(Window.Property(button.seek))">SetProperty(show.OSD,1)</onclick>
         </control>
         <control type="group" id="802">
             <visible>[!String.IsEmpty(Window.Property(show.OSD)) | Window.IsVisible(seekbar) | !String.IsEmpty(Window.Property(button.seek))] + !Window.IsVisible(osdvideosettings) + !Window.IsVisible(osdaudiosettings) + !Window.IsVisible(subtitlesearch) + !Window.IsActive(playerprocessinfo)</visible>


### PR DESCRIPTION
- try instantly hiding the OSD after a video has been resumed (depending on the skin and optionally the skinhelperservice) #172 
- using the left/right buttons without any OSD shown now do skipping (30/-10) instead of showing the OSD and seeking on the timeline
- skipping without an OSD shown now properly visually indicated
- automatically apply the currently selected seeking from the timeline after a 1 second delay
- increase the delay after which a skipping gets applied from 0.5s to 1s
- visually indicate negative seeking by adjusting the timeline dynamically #181
- auto-pause after seeking/skipping if the seek/skip was done when the video was paused instead of instantly resuming
- add addon setting for using configured kodi skip steps instead of 30/-10 #133 