### PR TITLE
Exit discovery/search using ACTION_PREVIOUS_MENU (ESCAPE) even while the search field has focus

### DIFF
--- a/lib/windows/kodigui.py
+++ b/lib/windows/kodigui.py
@@ -815,9 +815,9 @@ class SafeControlEdit(object):
             self._text = self._win.getControl(self.controlID).getText()
 
             if self._keyCallback:
-                self._keyCallback()
+                self._keyCallback(action_id)
 
-            self. updateLabel()
+            self.updateLabel()
 
             return True
 
@@ -835,7 +835,7 @@ class SafeControlEdit(object):
             return False
 
         if self._keyCallback:
-            self._keyCallback()
+            self._keyCallback(action_id)
 
         return True
 

--- a/lib/windows/search.py
+++ b/lib/windows/search.py
@@ -221,7 +221,12 @@ class SearchDialog(kodigui.BaseDialog, windowutils.UtilMixin):
         if 2099 < controlID < 2200:
             self.setProperty('hub.focus', str(controlID - 2099))
 
-    def updateFromEdit(self):
+    def updateFromEdit(self, actionID):
+        if actionID == xbmcgui.ACTION_PREVIOUS_MENU:
+            self.isActive = False
+            self.doClose()
+            return
+
         self.updateQuery()
 
     def updateQuery(self):

--- a/lib/windows/search.py
+++ b/lib/windows/search.py
@@ -189,7 +189,7 @@ class SearchDialog(kodigui.BaseDialog, windowutils.UtilMixin):
         )
 
         self.edit = kodigui.SafeControlEdit(650, 651, self, key_callback=self.updateFromEdit, grab_focus=True)
-        self.edit.setCompatibleMode(rpc.Application.GetProperties(properties=["version"])["major"] < 17)
+        self.edit.setCompatibleMode(rpc.Application.GetProperties(properties=["version"])["version"]["major"] < 17)
 
         self.setProperty('search.section', 'all')
         self.updateQuery()


### PR DESCRIPTION
GHI (If applicable): #174

## Description:
Currently the discovery/search window is only exitable using the search/discovery button itself. ACTION_PREVIOUS_MENU (in my case, the key `ESCAPE`) doesn't do that.

Also fixes an exception which was reproducable due to wrong usage of the rpc version response.

## Checklist:
- [x] I have based this PR against the develop branch
