### PR TITLE
Unwatched Filter Play and Shuffle

### DIFF
--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -830,6 +830,10 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
         else:
             args['sourceType'] = '8'
 
+        # When the list is filtered by unwatched, play and shuffle button should only play unwatched videos
+        if self.filterUnwatched:
+            args['unwatched'] = '1'
+
         pq = playqueue.createPlayQueueForItem(self.section, options={'shuffle': shuffle}, args=args)
         opener.open(pq)
 


### PR DESCRIPTION
Unwatched Filter Play and Shuffle

GHI (If applicable): #

## Description:
When a library list is filtered by unwatched, the play and shuffle button should only play unwatched media. This behavior has been established in web, android, and android tv apps.

## Checklist:
- [X] I have based this PR against the develop branch
