### PR TITLE
home hub: don't queue multiple hub item list pagination threads while one is active

### DIFF
--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -582,7 +582,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
     def checkHubItem(self, controlID):
         control = self.hubControls[controlID - 400]
         mli = control.getSelectedItem()
-        if not mli or not mli.getProperty('is.end'):
+        if not mli or not mli.getProperty('is.end') or mli.getProperty('is.updating') == '1':
             return
 
         mli.setBoolProperty('is.updating', True)

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -98,16 +98,16 @@ class UpdateHubTask(backgroundthread.Task):
 
 
 class ExtendHubTask(backgroundthread.Task):
-    def setup(self, hub, callback, canceled_callback=None):
+    def setup(self, hub, callback, canceledCallback=None):
         self.hub = hub
         self.callback = callback
-        self.canceled_callback = canceled_callback
+        self.canceledCallback = canceledCallback
         return self
 
     def run(self):
         if self.isCanceled():
-            if self.canceled_callback:
-                self.canceled_callback(self.hub)
+            if self.canceledCallback:
+                self.canceledCallback(self.hub)
             return
 
         if not plexapp.SERVERMANAGER.selectedServer:
@@ -118,14 +118,14 @@ class ExtendHubTask(backgroundthread.Task):
             start = self.hub.offset.asInt() + self.hub.size.asInt()
             items = self.hub.extend(start=start, size=HUB_PAGE_SIZE)
             if self.isCanceled():
-                if self.canceled_callback:
-                    self.canceled_callback(self.hub)
+                if self.canceledCallback:
+                    self.canceledCallback(self.hub)
                 return
             self.callback(self.hub, items)
         except plexnet.exceptions.BadRequest:
             util.DEBUG_LOG('404 on hub: {0}'.format(repr(self.hub.hubIdentifier)))
-            if self.canceled_callback:
-                self.canceled_callback(self.hub)
+            if self.canceledCallback:
+                self.canceledCallback(self.hub)
 
 
 class HomeSection(object):
@@ -595,7 +595,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         mli.setBoolProperty('is.updating', True)
         self.cleanTasks()
         task = ExtendHubTask().setup(control.dataSource, self.extendHubCallback,
-                                     canceled_callback=lambda hub: mli.setBoolProperty('is.updating', False))
+                                     canceledCallback=lambda hub: mli.setBoolProperty('is.updating', False))
         self.tasks.append(task)
         backgroundthread.BGThreader.addTask(task)
 


### PR DESCRIPTION
GHI (If applicable): #177

## Description:
When continuing to scroll right on a hub item list, triggering a pagination load, multiple tasks with possibly the same hub offset values are queued. This leads to duplicate pagination results.

This PR attempts to fix that by checking whether a hub item list pagination task is already queued and throws the subsequent calls away.

## Checklist:
- [x] I have based this PR against the develop branch
