### PR TITLE
Improve auto play from home handling for episodes

### DIFF
--- a/lib/windows/opener.py
+++ b/lib/windows/opener.py
@@ -23,9 +23,7 @@ def open(obj, auto_play=False):
             key = '/library/metadata/{0}'.format(obj)
         return open(plexapp.SERVERMANAGER.selectedServer.getObject(key))
     elif obj.TYPE == 'episode':
-        if not auto_play:
-            return episodeClicked(obj)
-        return playableClicked(obj, auto_play=auto_play)
+        return episodeClicked(obj, auto_play=auto_play)
     elif obj.TYPE == 'movie':
         return playableClicked(obj, auto_play=auto_play)
     elif obj.TYPE in ('show'):
@@ -74,9 +72,9 @@ def playableClicked(playable, auto_play=False):
     return handleOpen(preplay.PrePlayWindow, video=playable, auto_play=auto_play)
 
 
-def episodeClicked(episode):
+def episodeClicked(episode, auto_play=False):
     import episodes
-    return handleOpen(episodes.EpisodesWindow, episode=episode)
+    return handleOpen(episodes.EpisodesWindow, episode=episode, auto_play=auto_play)
 
 
 def showClicked(show):

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -57,7 +57,7 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
     def __init__(self, *args, **kwargs):
         kodigui.ControlledWindow.__init__(self, *args, **kwargs)
         self.video = kwargs.get('video')
-        self.auto_play = kwargs.get('auto_play')
+        self.autoPlay = kwargs.get('auto_play')
         self.parentList = kwargs.get('parent_list')
         self.videos = None
         self.exitCommand = None
@@ -72,8 +72,8 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.progressImageControl = self.getControl(self.PROGRESS_IMAGE_ID)
         self.setup()
 
-        if self.auto_play:
-            self.auto_play = False
+        if self.autoPlay:
+            self.autoPlay = False
             self.playVideo()
 
     def onReInit(self):


### PR DESCRIPTION
GHI (If applicable): #5

## Description:
This is a follow-up to PR #184 with a cleaner auto play approach for episodes. It now uses the `EpisodesWindow` for auto play of episodes instead of the `PrePlayWindow`. Post-play-behaviour should be as expected now.

## Checklist:
- [x] I have based this PR against the develop branch
