### PR TITLE
Play show theme music in the background

### DIFF
--- a/lib/_included_packages/plexnet/plexobjects.py
+++ b/lib/_included_packages/plexnet/plexobjects.py
@@ -65,7 +65,7 @@ class PlexValue(unicode):
         return dt.strftime(format_)
 
     def asURL(self):
-        return self.parent.server.url(self)
+        return self.parent.server.buildUrl(self, True)
 
     def asTranscodedImageURL(self, w, h, **extras):
         return self.parent.server.getImageTranscodeURL(self, w, h, **extras)

--- a/lib/_included_packages/plexnet/plexobjects.py
+++ b/lib/_included_packages/plexnet/plexobjects.py
@@ -64,8 +64,8 @@ class PlexValue(unicode):
 
         return dt.strftime(format_)
 
-    def asURL(self):
-        return self.parent.server.buildUrl(self, True)
+    def asURL(self, includeToken=False):
+        return self.parent.server.buildUrl(self, includeToken)
 
     def asTranscodedImageURL(self, w, h, **extras):
         return self.parent.server.getImageTranscodeURL(self, w, h, **extras)

--- a/lib/player.py
+++ b/lib/player.py
@@ -465,7 +465,7 @@ class AudioPlayerHandler(BasePlayerHandler):
         self.extractTrackInfo()
 
     def extractTrackInfo(self):
-        if not self.player.isPlayingAudio():
+        if not self.player.isPlayingAudio() or BGMUSICPLAYER.playing:
             return
 
         plexID = None
@@ -621,6 +621,9 @@ class AudioPlayerHandler(BasePlayerHandler):
         util.setGlobalProperty('track.ID', '')
 
     def tick(self):
+        if BGMUSICPLAYER.playing:
+            return
+
         self.stampCurrentTime()
         self.updateNowPlaying(force=True)
 
@@ -1080,6 +1083,7 @@ class BGMusicPlayer(xbmc.Player):
         xbmc.executebuiltin("SetVolume(%s)" % util.advancedSettings.themeMusicVolume)
         self._playing = True
         self.hasPlayed = True
+        util.setGlobalProperty('theme_playing', '1')
         return super(BGMusicPlayer, self).play(*args, **kwargs)
 
     def onPlayBackStarted(self):
@@ -1092,12 +1096,14 @@ class BGMusicPlayer(xbmc.Player):
             xbmc.executebuiltin("SetVolume(%s)" % self.old_volume)
 
         self._playing = False
+        util.setGlobalProperty('theme_playing', '')
 
     def onPlayBackEnded(self):
         if self._playing:
             xbmc.executebuiltin("SetVolume(%s)" % self.old_volume)
 
         self._playing = False
+        util.setGlobalProperty('theme_playing', '')
 
     @property
     def playing(self):

--- a/lib/player.py
+++ b/lib/player.py
@@ -1077,6 +1077,10 @@ class BGMusicPlayer(xbmc.Player):
         self.hasPlayed = False
 
     def play(self, *args, **kwargs):
+        # someone else is playing but not us, ignore
+        if self.isPlaying() and not self._playing:
+            return
+
         if not self._playing:
             self.old_volume = util.rpc.Application.GetProperties(properties=["volume"])["volume"]
 

--- a/lib/player.py
+++ b/lib/player.py
@@ -1074,7 +1074,9 @@ class BGMusicPlayer(xbmc.Player):
         self.hasPlayed = False
 
     def play(self, *args, **kwargs):
-        self.old_volume = util.rpc.Application.GetProperties(properties=["volume"])["volume"]
+        if not self._playing:
+            self.old_volume = util.rpc.Application.GetProperties(properties=["volume"])["volume"]
+
         xbmc.executebuiltin("SetVolume(%s)" % util.advancedSettings.themeMusicVolume)
         self._playing = True
         self.hasPlayed = True

--- a/lib/util.py
+++ b/lib/util.py
@@ -475,6 +475,8 @@ class AdvancedSettings(object):
 
     _proxiedSettings = (
         ("debug", False),
+        ("theme_music_shows", False),
+        ("theme_music_volume", 80),
     )
 
     def __init__(self):

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -126,6 +126,12 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         if self.autoPlay:
             self.autoPlay = False
             self.playButtonClicked(force_episode=self.initialEpisode)
+        else:
+            # we've come from a home hub view, play the current item's show's theme song
+            if self.initialEpisode:
+                theme = self.initialEpisode.show().theme
+                if theme:
+                    player.BGMUSICPLAYER.play(theme.asURL())
 
     def onReInit(self):
         self.selectEpisode()

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -128,7 +128,7 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             self.playButtonClicked(force_episode=self.initialEpisode)
         else:
             # we've come from a home hub view, play the current item's show's theme song
-            if self.initialEpisode:
+            if self.initialEpisode and util.advancedSettings.themeMusicShows:
                 theme = self.initialEpisode.show().theme
                 if theme:
                     player.BGMUSICPLAYER.play(theme.asURL())

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -131,7 +131,7 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             if self.initialEpisode and util.advancedSettings.themeMusicShows:
                 theme = self.initialEpisode.show().theme
                 if theme:
-                    player.BGMUSICPLAYER.play(theme.asURL())
+                    player.BGMUSICPLAYER.play(theme.asURL(True))
 
     def onReInit(self):
         self.selectEpisode()

--- a/lib/windows/subitems.py
+++ b/lib/windows/subitems.py
@@ -91,7 +91,7 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.setFocusId(self.PLAY_BUTTON_ID)
 
         if self.mediaItem.theme and util.advancedSettings.themeMusicShows:
-            player.BGMUSICPLAYER.play(self.mediaItem.theme.asURL())
+            player.BGMUSICPLAYER.play(self.mediaItem.theme.asURL(True))
 
     def setup(self):
         self.mediaItem.reload(includeRelated=1, includeRelatedCount=10, includeExtras=1, includeExtrasCount=10)

--- a/lib/windows/subitems.py
+++ b/lib/windows/subitems.py
@@ -90,7 +90,7 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
 
         self.setFocusId(self.PLAY_BUTTON_ID)
 
-        if self.mediaItem.theme:
+        if self.mediaItem.theme and util.advancedSettings.themeMusicShows:
             player.BGMUSICPLAYER.play(self.mediaItem.theme.asURL())
 
     def setup(self):

--- a/lib/windows/subitems.py
+++ b/lib/windows/subitems.py
@@ -7,6 +7,7 @@ import kodigui
 from lib import colors
 from lib import util
 from lib import metadata
+from lib import player
 
 from plexnet import playlist
 
@@ -88,6 +89,9 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.setup()
 
         self.setFocusId(self.PLAY_BUTTON_ID)
+
+        if self.mediaItem.theme:
+            player.BGMUSICPLAYER.play(self.mediaItem.theme.asURL())
 
     def setup(self):
         self.mediaItem.reload(includeRelated=1, includeRelatedCount=10, includeExtras=1, includeExtrasCount=10)

--- a/lib/windows/videoplayer.py
+++ b/lib/windows/videoplayer.py
@@ -516,6 +516,9 @@ class VideoPlayerWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
 
 
 def play(video=None, play_queue=None, resume=False):
+    if player.BGMUSICPLAYER.playing:
+        player.BGMUSICPLAYER.stop()
+
     w = VideoPlayerWindow.open(video=video, play_queue=play_queue, resume=resume)
     player.PLAYER.off('session.ended', w.sessionEnded)
     player.PLAYER.off('post.play', w.postPlay)

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -951,3 +951,14 @@ msgctxt "#32463"
 msgid "By Artist"
 msgstr ""
 
+msgctxt "#32467"
+msgid "Appearance"
+msgstr ""
+
+msgctxt "#32472"
+msgid "Play theme music for shows"
+msgstr ""
+
+msgctxt "#32473"
+msgid "Theme music volume"
+msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -949,3 +949,15 @@ msgstr "Künstler(in)"
 msgctxt "#32463"
 msgid "By Artist"
 msgstr "Nach Künstler(in)"
+
+msgctxt "#32467"
+msgid "Darstellung"
+msgstr ""
+
+msgctxt "#32472"
+msgid "Titelmusik für Serien abspielen"
+msgstr ""
+
+msgctxt "#32473"
+msgid "Titelmusik-Lautstärke"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,4 +9,8 @@
     <setting id="debug" type="bool" label="32024" default="false" />
   </category>
 
+  <category label="32467">
+    <setting id="theme_music_shows" type="bool" label="32472" default="false" />
+    <setting id="theme_music_volume" type="slider" label="32473" default="80" range="0,5,100" option="percent" />
+  </category>
 </settings>

--- a/resources/skins/Main/1080i/script-plex-album.xml
+++ b/resources/skins/Main/1080i/script-plex-album.xml
@@ -470,11 +470,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-artist.xml
+++ b/resources/skins/Main/1080i/script-plex-artist.xml
@@ -369,11 +369,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-episodes.xml
+++ b/resources/skins/Main/1080i/script-plex-episodes.xml
@@ -1206,11 +1206,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-home.xml
+++ b/resources/skins/Main/1080i/script-plex-home.xml
@@ -7814,11 +7814,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-info.xml
+++ b/resources/skins/Main/1080i/script-plex-info.xml
@@ -151,11 +151,11 @@
             <height>135</height>
 
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-listview-16x9-chunked.xml
+++ b/resources/skins/Main/1080i/script-plex-listview-16x9-chunked.xml
@@ -653,11 +653,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-listview-16x9.xml
+++ b/resources/skins/Main/1080i/script-plex-listview-16x9.xml
@@ -605,11 +605,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-listview-square-chunked.xml
+++ b/resources/skins/Main/1080i/script-plex-listview-square-chunked.xml
@@ -722,11 +722,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-listview-square.xml
+++ b/resources/skins/Main/1080i/script-plex-listview-square.xml
@@ -674,11 +674,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-playlist.xml
+++ b/resources/skins/Main/1080i/script-plex-playlist.xml
@@ -652,11 +652,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-playlists.xml
+++ b/resources/skins/Main/1080i/script-plex-playlists.xml
@@ -409,11 +409,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-posters.xml
+++ b/resources/skins/Main/1080i/script-plex-posters.xml
@@ -560,11 +560,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-pre_play.xml
+++ b/resources/skins/Main/1080i/script-plex-pre_play.xml
@@ -974,11 +974,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-seasons.xml
+++ b/resources/skins/Main/1080i/script-plex-seasons.xml
@@ -1055,11 +1055,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-settings.xml
+++ b/resources/skins/Main/1080i/script-plex-settings.xml
@@ -574,11 +574,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-squares.xml
+++ b/resources/skins/Main/1080i/script-plex-squares.xml
@@ -482,11 +482,11 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Player.HasAudio</visible>
+                <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                 <posx>438</posx>
                 <posy>0</posy>
                 <control type="button" id="204">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>-10</posx>
                     <posy>38</posy>
                     <width>260</width>

--- a/resources/skins/Main/1080i/script-plex-user_select.xml
+++ b/resources/skins/Main/1080i/script-plex-user_select.xml
@@ -28,7 +28,7 @@
 
         <control type="group">
             <animation effect="fade" time="100" start="100" end="20" condition="ControlGroup(400).HasFocus(0)">Conditional</animation>
-            <visible>Player.HasAudio</visible>
+            <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
             <posx>441</posx>
             <posy>780</posy>
 

--- a/resources/skins/Main/1080i/script-plex-video_player.xml
+++ b/resources/skins/Main/1080i/script-plex-video_player.xml
@@ -901,11 +901,11 @@
                     </control>
                 </control>
                 <control type="group">
-                    <visible>Player.HasAudio</visible>
+                    <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                     <posx>438</posx>
                     <posy>0</posy>
                     <control type="button" id="204">
-                        <visible>Player.HasAudio</visible>
+                        <visible>Player.HasAudio + String.IsEmpty(Window(10000).Property(script.plex.theme_playing))</visible>
                         <posx>-10</posx>
                         <posy>38</posy>
                         <width>260</width>


### PR DESCRIPTION
GHI (If applicable): #2 

## Description:
Plays the current episode's show theme music, or in case of a library-show-visit, the show's theme music.

Adds options for that (off by default) and a volume slider for the theme volume.

## Checklist:
- [x] I have based this PR against the develop branch
