### PR TITLE
Show post play even if playback was stopped

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -316,6 +316,10 @@ class SeekPlayerHandler(BasePlayerHandler):
         if self.seeking not in (self.SEEK_IN_PROGRESS, self.SEEK_REWIND):
             self.updateNowPlaying()
 
+            # show post play if possible, if an item has been watched (90% by Plex standards)
+            if self.trueTime * 1000 / float(self.duration) >= 0.90 and self.next(on_end=True):
+                return
+
         if self.seeking not in (self.SEEK_IN_PROGRESS, self.SEEK_PLAYLIST):
             self.hideOSD(delete=True)
             self.sessionEnded()


### PR DESCRIPTION
GHI (If applicable): #

## Description:
Shows the post play screen even if playback was stopped instead of ended and the item is considered watched by Plex standards (90%).

## Checklist:
- [x] I have based this PR against the develop branch
