### PR TITLE
Show PlayerProcessInfo in playback view

### DIFF
--- a/lib/windows/playersettings.py
+++ b/lib/windows/playersettings.py
@@ -144,7 +144,7 @@ class VideoSettingsDialog(kodigui.BaseDialog, util.CronReceiver):
         elif result == 'kodi_audio':
             xbmc.executebuiltin('ActivateWindow(OSDAudioSettings)')
         elif result == "stream_info":
-            xbmc.executebuiltin('ActivateWindow(PlayerProcessInfo)')
+            xbmc.executebuiltin('Action(PlayerProcessInfo)')
 
         self.showSettings()
 

--- a/lib/windows/playersettings.py
+++ b/lib/windows/playersettings.py
@@ -87,6 +87,11 @@ class VideoSettingsDialog(kodigui.BaseDialog, util.CronReceiver):
                 ('kodi_audio', T(32399, 'Kodi Audio Settings'), '')
             ]
 
+        if self.viaOSD:
+            options += [
+                ('stream_info', T(32483, 'Stream Info'), ''),
+            ]
+
         items = []
         for o in options:
             item = kodigui.ManagedListItem(o[1], o[2], data_source=o[0])
@@ -138,6 +143,8 @@ class VideoSettingsDialog(kodigui.BaseDialog, util.CronReceiver):
             xbmc.executebuiltin('ActivateWindow(OSDVideoSettings)')
         elif result == 'kodi_audio':
             xbmc.executebuiltin('ActivateWindow(OSDAudioSettings)')
+        elif result == "stream_info":
+            xbmc.executebuiltin('ActivateWindow(PlayerProcessInfo)')
 
         self.showSettings()
 

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -966,3 +966,7 @@ msgstr ""
 msgctxt "#32471"
 msgid "Use Plex/Kodi steps for timeline"
 msgstr ""
+
+msgctxt "#32483"
+msgid "Stream Info"
+msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -965,3 +965,7 @@ msgstr "Nach Verzögerung automatisch zur aktuell gewählten Position springen"
 msgctxt "#32471"
 msgid "Use Plex/Kodi steps for timeline"
 msgstr "Plex/Kodi-Skip-Schritte für die Zeitachse verwenden"
+
+msgctxt "#32483"
+msgid "Stream Info"
+msgstr "Stream Info"

--- a/resources/skins/Main/1080i/script-plex-seek_dialog.xml
+++ b/resources/skins/Main/1080i/script-plex-seek_dialog.xml
@@ -180,7 +180,7 @@
             </control>
         </control>
         <control type="group" id="801">
-            <visible>!String.IsEmpty(Window.Property(show.OSD)) + !Window.IsVisible(osdvideosettings) + !Window.IsVisible(osdaudiosettings)</visible>
+            <visible>!String.IsEmpty(Window.Property(show.OSD)) + !Window.IsVisible(osdvideosettings) + !Window.IsVisible(osdaudiosettings) + !Window.IsVisible(playerprocessinfo)</visible>
             <animation effect="fade" time="200" delay="200" end="0">Hidden</animation>
             <control type="group" id="300">
                 <visible>!String.IsEmpty(Window.Property(has.bif)) + [Control.HasFocus(100) | Control.HasFocus(501) | !String.IsEmpty(Window.Property(button.seek))]</visible>

--- a/resources/skins/Main/1080i/script-plex-video_settings_dialog.xml
+++ b/resources/skins/Main/1080i/script-plex-video_settings_dialog.xml
@@ -22,7 +22,7 @@
             </control>
         </control>
         <control type="group">
-            <visible>!Window.IsVisible(sliderdialog) + !Window.IsVisible(osdvideosettings) + !Window.IsVisible(osdaudiosettings)</visible>
+            <visible>!Window.IsVisible(sliderdialog) + !Window.IsVisible(osdvideosettings) + !Window.IsVisible(osdaudiosettings) + !Window.IsVisible(playerprocessinfo)</visible>
             <posx>460</posx>
             <posy>200</posy>
             <control type="image">


### PR DESCRIPTION
GHI (If applicable): #

## Description:
Shows the Kodi PlayerProcessInfo (CodecInfo) on demand, in the playback settings.

## Checklist:
- [x] I have based this PR against the develop branch
