### PR TITLE
Regression fixes for seek PR

### DIFF
--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -866,6 +866,7 @@ class SeekDialog(kodigui.BaseDialog):
     def hideOSD(self):
         self.setProperty('show.OSD', '')
         self.setFocusId(self.NO_OSD_BUTTON_ID)
+        self.resetSeeking()
         self._osdHideFast = False
         if self.playlistDialog:
             self.playlistDialog.doClose()

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -581,6 +581,7 @@ class SeekDialog(kodigui.BaseDialog):
 
     def updateBigSeek(self):
         self.selectedOffset = self.bigSeekControl.getSelectedItem().dataSource + self.bigSeekOffset
+        self.updateProgress(set_to_current=False)
         self.resetSkipSteps()
 
     def bigSeekSelected(self):


### PR DESCRIPTION
GHI (If applicable): #

## Description:
Fixes two issues introduced with the new seeking mechanism:
- properly resets the current seeking when the OSD is hidden (otherwise hitting OK after an unapplied seek would apply the old offset)
- shows the current time position indicator for the bigseek again

## Checklist:
- [x] I have based this PR against the develop branch
