### PR TITLE
Directplay playback fixes

### DIFF
--- a/lib/_included_packages/plexnet/mediadecisionengine.py
+++ b/lib/_included_packages/plexnet/mediadecisionengine.py
@@ -176,8 +176,8 @@ class MediaDecisionEngine(object):
             util.LOG("MDE: Need to burn in subtitles")
         elif choice.protocol != "http":
             util.LOG("MDE: " + choice.protocol + " not supported")
-        elif numVideoStreams > 1:
-            util.LOG("MDE: Multiple video streams, won't try to direct play")
+        # elif numVideoStreams > 1:
+        #     util.LOG("MDE: Multiple video streams, won't try to direct play")
         elif problematicAudioStream:
             util.LOG("MDE: Problematic AAC stream with more than 2 channels prevents direct play")
         elif self.canDirectPlay(item, choice):

--- a/lib/_included_packages/plexnet/plexapp.py
+++ b/lib/_included_packages/plexnet/plexapp.py
@@ -159,7 +159,7 @@ class AppInterface(object):
             maxResolution = "1080p"
 
         self._globals['qualities'] = [
-            simpleobjects.AttributeDict({'title': "Original", 'index': 13, 'maxBitrate': 200000}),
+            simpleobjects.AttributeDict({'title': "Original", 'index': 13, 'maxBitrate': 1000000}),
             simpleobjects.AttributeDict({'title': "20 Mbps " + maxResolution, 'index': 12, 'maxBitrate': 20000}),
             simpleobjects.AttributeDict({'title': "12 Mbps " + maxResolution, 'index': 11, 'maxBitrate': 12000}),
             simpleobjects.AttributeDict({'title': "10 Mbps " + maxResolution, 'index': 10, 'maxBitrate': 10000}),

--- a/lib/_included_packages/plexnet/plexplayer.py
+++ b/lib/_included_packages/plexnet/plexplayer.py
@@ -330,9 +330,9 @@ class PlexPlayer(object):
         # Augment the server's profile for things that depend on the Roku's configuration.
         if self.item.settings.supportsSurroundSound():
             if self.choice.audioStream is not None:
-                numChannels = self.choice.audioStream.channels.asInt(6)
+                numChannels = self.choice.audioStream.channels.asInt(8)
             else:
-                numChannels = 6
+                numChannels = 8
 
             for codec in ("ac3", "eac3", "dca"):
                 if self.item.settings.supportsAudioStream(codec, numChannels):
@@ -340,7 +340,7 @@ class PlexPlayer(object):
                     builder.extras.append("add-direct-play-profile(type=videoProfile&container=matroska&videoCodec=*&audioCodec=" + codec + ")")
                     if codec == "dca":
                         builder.extras.append(
-                            "add-limitation(scope=videoAudioCodec&scopeName=dca&type=upperBound&name=audio.channels&value=6&isRequired=false)"
+                            "add-limitation(scope=videoAudioCodec&scopeName=dca&type=upperBound&name=audio.channels&value=8&isRequired=false)"
                         )
 
         # AAC sample rate cannot be less than 22050hz (HLS is capable).


### PR DESCRIPTION
GHI (If applicable): #224 #214 

## Description:
- raises the bitrate limit for "Original" quality to 1gbit from 200mbit
- increases the ~~DP-supported~~ transcode-path channel count for DCA from 6 to 8
- re-enables direct play for videos with multiple video streams

## Checklist:
- [x] I have based this PR against the develop branch
