### PR TITLE
Auto play quickly from the home hub without showing the actual preplay screen

### DIFF
--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -88,7 +88,6 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.reset(kwargs.get('episode'), kwargs.get('season'), kwargs.get('show'))
         self.initialEpisode = kwargs.get('episode')
         self.parentList = kwargs.get('parentList')
-        self.autoPlay = kwargs.get('auto_play')
         self.lastItem = None
         self.lastFocusID = None
         self.tasks = backgroundthread.Tasks()
@@ -109,7 +108,7 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         player.PLAYER.off('new.video', self.onNewVideo)
 
     @busy.dialog()
-    def _onFirstInit(self):
+    def onFirstInit(self):
         self.episodeListControl = kodigui.ManagedControlList(self, self.EPISODE_LIST_ID, 5)
         self.progressImageControl = self.getControl(self.PROGRESS_IMAGE_ID)
 
@@ -120,12 +119,8 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self._setup()
         self.postSetup()
 
-    def onFirstInit(self):
-        self._onFirstInit()
-
-        if self.autoPlay:
-            self.autoPlay = False
-            self.playButtonClicked(force_episode=self.initialEpisode)
+    def doAutoPlay(self):
+        return self.playButtonClicked(force_episode=self.initialEpisode)
 
     def onReInit(self):
         self.selectEpisode()
@@ -420,8 +415,10 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
 
             pl.shuffle(shuffle, first=True)
             videoplayer.play(play_queue=pl)
+            return True
+
         else:
-            self.episodeListClicked(force_episode=force_episode)
+            return self.episodeListClicked(force_episode=force_episode)
 
     def shuffleButtonClicked(self):
         self.playButtonClicked(shuffle=True)
@@ -500,9 +497,10 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         if len(pl):  # Don't use playlist if it's only this video
             pl.setCurrent(episode)
             self.processCommand(videoplayer.play(play_queue=pl, resume=resume))
-            return
+            return True
 
         self.processCommand(videoplayer.play(video=episode, resume=resume))
+        return True
 
     def optionsButtonClicked(self, from_item=False):
         options = []

--- a/lib/windows/opener.py
+++ b/lib/windows/opener.py
@@ -56,7 +56,13 @@ def open(obj, auto_play=False):
 def handleOpen(winclass, **kwargs):
     w = None
     try:
-        w = winclass.open(**kwargs)
+        autoPlay = kwargs.pop("auto_play", False)
+        if autoPlay and hasattr(winclass, "doAutoPlay"):
+            w = winclass.create(show=False, **kwargs)
+            if w.doAutoPlay():
+                w.modal()
+        else:
+            w = winclass.open(**kwargs)
         return w.exitCommand or ''
     except AttributeError:
         pass

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -57,7 +57,6 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
     def __init__(self, *args, **kwargs):
         kodigui.ControlledWindow.__init__(self, *args, **kwargs)
         self.video = kwargs.get('video')
-        self.autoPlay = kwargs.get('auto_play')
         self.parentList = kwargs.get('parent_list')
         self.videos = None
         self.exitCommand = None
@@ -72,9 +71,8 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.progressImageControl = self.getControl(self.PROGRESS_IMAGE_ID)
         self.setup()
 
-        if self.autoPlay:
-            self.autoPlay = False
-            self.playVideo()
+    def doAutoPlay(self):
+        return self.playVideo()
 
     def onReInit(self):
         self.video.reload()
@@ -402,6 +400,7 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             resume = (button == 0)
 
         self.processCommand(videoplayer.play(video=self.video, resume=resume))
+        return True
 
     def openItem(self, control=None, item=None):
         if not item:


### PR DESCRIPTION
GHI (If applicable): #

## Description:
Instead of showing the preplay screen when pressing PLAY on an item from the home screen, play the video directly and show the window afterwards, if necessary.

## Checklist:
- [x] I have based this PR against the develop branch
