### PR TITLE
Unify client behaviour: Show mark unplayed even if video in progress

### DIFF
--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -513,10 +513,10 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             if len(mli.dataSource.media) > 1:
                 options.append({'key': 'play_version', 'display': T(32451, 'Play Version...')})
 
-            if mli.dataSource.isWatched and not mli.dataSource.viewOffset.asInt():
-                options.append({'key': 'mark_unwatched', 'display': T(32318, 'Mark Unplayed')})
-            else:
+            if not mli.dataSource.isWatched or mli.dataSource.viewOffset.asInt():
                 options.append({'key': 'mark_watched', 'display': T(32319, 'Mark Played')})
+            if mli.dataSource.isWatched or mli.dataSource.viewOffset.asInt():
+                options.append({'key': 'mark_unwatched', 'display': T(32318, 'Mark Unplayed')})
 
             # if True:
             #     options.append({'key': 'add_to_playlist', 'display': '[COLOR FF808080]Add To Playlist[/COLOR]'})

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -183,10 +183,10 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         if len(self.video.media) > 1:
             options.append({'key': 'play_version', 'display': T(32451, 'Play Version...')})
 
-        if self.video.isWatched and not self.video.viewOffset.asInt():
-            options.append({'key': 'mark_unwatched', 'display': T(32318, 'Mark Unplayed')})
-        else:
+        if not self.video.isWatched or self.video.viewOffset.asInt():
             options.append({'key': 'mark_watched', 'display': T(32319, 'Mark Played')})
+        if self.video.isWatched or self.video.viewOffset.asInt():
+            options.append({'key': 'mark_unwatched', 'display': T(32318, 'Mark Unplayed')})
 
         options.append(dropdown.SEPARATOR)
 


### PR DESCRIPTION
GHI (If applicable): #

## Description:
PlexWeb shows Mark Unplayed and Mark Played options together if an item is in progress. Do the same.

## Checklist:
- [x] I have based this PR against the develop branch
