### PR TITLE
Add play state info to related items

### DIFF
--- a/lib/_included_packages/plexnet/video.py
+++ b/lib/_included_packages/plexnet/video.py
@@ -91,15 +91,15 @@ class Video(media.MediaItem):
         """
         self.server.query('/%s/analyze' % self.key)
 
-    def markWatched(self):
+    def markWatched(self, **kwargs):
         path = '/:/scrobble?key=%s&identifier=com.plexapp.plugins.library' % self.ratingKey
         self.server.query(path)
-        self.reload()
+        self.reload(**kwargs)
 
-    def markUnwatched(self):
+    def markUnwatched(self, **kwargs):
         path = '/:/unscrobble?key=%s&identifier=com.plexapp.plugins.library' % self.ratingKey
         self.server.query(path)
-        self.reload()
+        self.reload(**kwargs)
 
     # def play(self, client):
     #     client.playMedia(self)

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -135,7 +135,7 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             return
 
         self.reloadItems(items=[mli])
-        self.fillRelated()
+        self.updateRelated()
 
     def postSetup(self, from_select_episode=False):
         self.selectEpisode(from_select_episode=from_select_episode)
@@ -861,6 +861,28 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.relatedListControl.reset()
         self.relatedListControl.addItems(items)
         return True
+
+    def updateRelated(self):
+        """
+        Update item watched/progress states dynamically
+        :return:
+        """
+        if not self.show_.related:
+            return False
+
+        states = {}
+        for rel in self.show_.related()[0].items:
+            states[rel.ratingKey] = {
+                "unwatched.count": str(rel.unViewedLeafCount),
+                "progress": util.getProgressImage(rel)
+            }
+
+        for mli in self.relatedListControl:
+            stateInfo = states.get(mli.dataSource.ratingKey)
+            if stateInfo:
+                for fillProperty in ("unwatched.count", "progress"):
+                    if mli.getProperty(fillProperty) != stateInfo[fillProperty]:
+                        mli.setProperty(fillProperty, stateInfo[fillProperty])
 
     def fillRoles(self, has_prev=False):
         items = []

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -873,7 +873,7 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         states = {}
         for rel in self.show_.related()[0].items:
             states[rel.ratingKey] = {
-                "unwatched.count": str(rel.unViewedLeafCount),
+                "unwatched.count": str(rel.unViewedLeafCount) if not rel.isWatched else '',
                 "progress": util.getProgressImage(rel)
             }
 

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -135,6 +135,7 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             return
 
         self.reloadItems(items=[mli])
+        self.fillRelated()
 
     def postSetup(self, from_select_episode=False):
         self.selectEpisode(from_select_episode=from_select_episode)
@@ -851,6 +852,9 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             if mli:
                 mli.setProperty('thumb.fallback', 'script.plex/thumb_fallbacks/{0}.png'.format(rel.type in ('show', 'season', 'episode') and 'show' or 'movie'))
                 mli.setProperty('index', str(idx))
+                if not mli.dataSource.isWatched:
+                    mli.setProperty('unwatched.count', str(mli.dataSource.unViewedLeafCount))
+                mli.setProperty('progress', util.getProgressImage(mli.dataSource))
                 items.append(mli)
                 idx += 1
 

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -21,6 +21,8 @@ from lib import metadata
 
 from lib.util import T
 
+VIDEO_RELOAD_KW = dict(includeRelated=1, includeRelatedCount=10)
+
 
 class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
     xmlFile = 'script-plex-pre_play.xml'
@@ -77,7 +79,7 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             self.playVideo()
 
     def onReInit(self):
-        self.video.reload()
+        self.video.reload(**VIDEO_RELOAD_KW)
         self.refreshInfo()
 
     def refreshInfo(self):
@@ -85,6 +87,7 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
 
         util.setGlobalProperty('hide.resume', '' if self.video.viewOffset.asInt() else '1')
         self.setInfo()
+        self.fillRelated()
         xbmc.sleep(100)
 
         if oldFocusId == self.PLAY_BUTTON_ID:
@@ -218,11 +221,11 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         elif choice['key'] == 'play_next':
             xbmc.executebuiltin('PlayerControl(Next)')
         elif choice['key'] == 'mark_watched':
-            self.video.markWatched()
+            self.video.markWatched(**VIDEO_RELOAD_KW)
             self.refreshInfo()
             util.MONITOR.watchStatusChanged()
         elif choice['key'] == 'mark_unwatched':
-            self.video.markUnwatched()
+            self.video.markUnwatched(**VIDEO_RELOAD_KW)
             self.refreshInfo()
             util.MONITOR.watchStatusChanged()
         elif choice['key'] == 'to_season':
@@ -429,7 +432,7 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         elif self.video.type == 'movie':
             self.setProperty('preview.no', '1')
 
-        self.video.reload(checkFiles=1, includeRelated=1, includeRelatedCount=10, includeExtras=1, includeExtrasCount=10)
+        self.video.reload(checkFiles=1, includeExtras=1, includeExtrasCount=10, **VIDEO_RELOAD_KW)
         self.setInfo()
         self.fillExtras()
         hasPrev = self.fillRelated()
@@ -572,6 +575,8 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             if mli:
                 mli.setProperty('thumb.fallback', 'script.plex/thumb_fallbacks/{0}.png'.format(rel.type in ('show', 'season', 'episode') and 'show' or 'movie'))
                 mli.setProperty('index', str(idx))
+                mli.setProperty('unwatched', not mli.dataSource.isWatched and '1' or '')
+                mli.setProperty('progress', util.getProgressImage(mli.dataSource))
                 items.append(mli)
                 idx += 1
 

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -87,7 +87,7 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
 
         util.setGlobalProperty('hide.resume', '' if self.video.viewOffset.asInt() else '1')
         self.setInfo()
-        self.fillRelated()
+        self.updateRelated()
         xbmc.sleep(100)
 
         if oldFocusId == self.PLAY_BUTTON_ID:
@@ -588,6 +588,26 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.relatedListControl.reset()
         self.relatedListControl.addItems(items)
         return True
+
+    def updateRelated(self):
+        if not self.video.related:
+            return False
+
+        states = {}
+        for rel in self.video.related()[0].items:
+            states[rel.ratingKey] = {
+                "unwatched": not rel.isWatched and '1' or '',
+                "progress": util.getProgressImage(rel)
+            }
+
+        for mli in self.relatedListControl:
+            stateInfo = states.get(mli.dataSource.ratingKey)
+            if stateInfo:
+                if mli.getProperty('unwatched') != stateInfo['unwatched']:
+                    mli.setProperty('unwatched', stateInfo['unwatched'])
+
+                if mli.getProperty('progress') != stateInfo['progress']:
+                    mli.setProperty('progress', stateInfo['progress'])
 
     def fillRoles(self, has_prev=False):
         items = []

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -590,6 +590,10 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         return True
 
     def updateRelated(self):
+        """
+        Update item watched/progress states dynamically
+        :return:
+        """
         if not self.video.related:
             return False
 
@@ -603,11 +607,9 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         for mli in self.relatedListControl:
             stateInfo = states.get(mli.dataSource.ratingKey)
             if stateInfo:
-                if mli.getProperty('unwatched') != stateInfo['unwatched']:
-                    mli.setProperty('unwatched', stateInfo['unwatched'])
-
-                if mli.getProperty('progress') != stateInfo['progress']:
-                    mli.setProperty('progress', stateInfo['progress'])
+                for fillProperty in ("unwatched", "progress"):
+                    if mli.getProperty(fillProperty) != stateInfo[fillProperty]:
+                        mli.setProperty(fillProperty, stateInfo[fillProperty])
 
     def fillRoles(self, has_prev=False):
         items = []

--- a/lib/windows/subitems.py
+++ b/lib/windows/subitems.py
@@ -538,6 +538,11 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             if mli:
                 mli.setProperty('thumb.fallback', 'script.plex/thumb_fallbacks/{0}.png'.format(rel.type in ('show', 'season', 'episode') and 'show' or 'movie'))
                 mli.setProperty('index', str(idx))
+                if rel.type in ('show', 'season'):
+                    if not mli.dataSource.isWatched:
+                        mli.setProperty('unwatched.count', str(mli.dataSource.unViewedLeafCount))
+                else:
+                    mli.setProperty('unwatched', not mli.dataSource.isWatched and '1' or '')
                 items.append(mli)
                 idx += 1
 

--- a/lib/windows/videoplayer.py
+++ b/lib/windows/videoplayer.py
@@ -369,9 +369,9 @@ class VideoPlayerWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             self.setProperty('prev.info.summary', self.prev.summary)
 
         if self.prev.type == 'episode':
+            self.setProperty('related.header', T(32306, 'Related Shows'))
             if self.next:
                 self.setProperty('next.thumb', self.next.thumb.asTranscodedImageURL(*self.NEXT_DIM))
-                self.setProperty('related.header', T(32306, 'Related Shows'))
                 self.setProperty('info.date', util.cleanLeadingZeros(self.next.originallyAvailableAt.asDatetime('%B %d, %Y')))
 
                 self.setProperty('next.title', self.next.grandparentTitle)
@@ -386,9 +386,9 @@ class VideoPlayerWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
                 )
                 self.setProperty('prev.info.date', util.cleanLeadingZeros(self.prev.originallyAvailableAt.asDatetime('%B %d, %Y')))
         elif self.prev.type == 'movie':
+            self.setProperty('related.header', T(32404, 'Related Movies'))
             if self.next:
                 self.setProperty('next.thumb', self.next.defaultArt.asTranscodedImageURL(*self.NEXT_DIM))
-                self.setProperty('related.header', T(32404, 'Related Movies'))
                 self.setProperty('info.date', self.next.year)
 
                 self.setProperty('next.title', self.next.title)

--- a/lib/windows/videoplayer.py
+++ b/lib/windows/videoplayer.py
@@ -418,6 +418,7 @@ class VideoPlayerWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             mli = kodigui.ManagedListItem(title or '', thumbnailImage=thumb, data_source=ondeck)
             if mli:
                 mli.setProperty('index', str(idx))
+                mli.setProperty('progress', util.getProgressImage(mli.dataSource))
                 mli.setProperty(
                     'thumb.fallback', 'script.plex/thumb_fallbacks/{0}.png'.format(ondeck.type in ('show', 'season', 'episode') and 'show' or 'movie')
                 )
@@ -451,6 +452,12 @@ class VideoPlayerWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             if mli:
                 mli.setProperty('thumb.fallback', 'script.plex/thumb_fallbacks/{0}.png'.format(rel.type in ('show', 'season', 'episode') and 'show' or 'movie'))
                 mli.setProperty('index', str(idx))
+                if self.prev and self.prev.type == 'episode':
+                    if not mli.dataSource.isWatched:
+                        mli.setProperty('unwatched.count', str(mli.dataSource.unViewedLeafCount))
+                else:
+                    mli.setProperty('unwatched', not mli.dataSource.isWatched and '1' or '')
+                mli.setProperty('progress', util.getProgressImage(mli.dataSource))
                 items.append(mli)
                 idx += 1
 

--- a/resources/skins/Main/1080i/script-plex-episodes.xml
+++ b/resources/skins/Main/1080i/script-plex-episodes.xml
@@ -878,6 +878,44 @@
                                             <colordiffuse>FFCC7B19</colordiffuse>
                                         </control>
                                     </control>
+                                    <control type="image">
+                                        <visible>!String.IsEmpty(ListItem.Property(unwatched))</visible>
+                                        <posx>196</posx>
+                                        <posy>0</posy>
+                                        <width>48</width>
+                                        <height>48</height>
+                                        <texture>script.plex/indicators/unwatched.png</texture>
+                                    </control>
+                                    <control type="group">
+                                        <visible>!String.IsEmpty(ListItem.Property(unwatched.count))</visible>
+                                        <control type="image">
+                                            <posx>193</posx>
+                                            <posy>0</posy>
+                                            <width>51</width>
+                                            <height>39</height>
+                                            <texture>script.plex/white-square.png</texture>
+                                            <colordiffuse>FF000000</colordiffuse>
+                                        </control>
+                                        <control type="image">
+                                            <posx>194</posx>
+                                            <posy>0</posy>
+                                            <width>50</width>
+                                            <height>38</height>
+                                            <texture>script.plex/white-square.png</texture>
+                                            <colordiffuse>FFCC7B19</colordiffuse>
+                                        </control>
+                                        <control type="label">
+                                            <posx>194</posx>
+                                            <posy>0</posy>
+                                            <width>50</width>
+                                            <height>38</height>
+                                            <font>font12</font>
+                                            <align>center</align>
+                                            <aligny>center</aligny>
+                                            <textcolor>FF000000</textcolor>
+                                            <label>$INFO[ListItem.Property(unwatched.count)]</label>
+                                        </control>
+                                    </control>
                                     <control type="label">
                                         <scroll>false</scroll>
                                         <posx>0</posx>
@@ -948,6 +986,44 @@
                                                 <height>8</height>
                                                 <texture>$INFO[ListItem.Property(progress)]</texture>
                                                 <colordiffuse>FFCC7B19</colordiffuse>
+                                            </control>
+                                        </control>
+                                        <control type="image">
+                                            <visible>!String.IsEmpty(ListItem.Property(unwatched))</visible>
+                                            <posx>196</posx>
+                                            <posy>0</posy>
+                                            <width>48</width>
+                                            <height>48</height>
+                                            <texture>script.plex/indicators/unwatched.png</texture>
+                                        </control>
+                                        <control type="group">
+                                            <visible>!String.IsEmpty(ListItem.Property(unwatched.count))</visible>
+                                            <control type="image">
+                                                <posx>193</posx>
+                                                <posy>0</posy>
+                                                <width>51</width>
+                                                <height>39</height>
+                                                <texture>script.plex/white-square.png</texture>
+                                                <colordiffuse>FF000000</colordiffuse>
+                                            </control>
+                                            <control type="image">
+                                                <posx>194</posx>
+                                                <posy>0</posy>
+                                                <width>50</width>
+                                                <height>38</height>
+                                                <texture>script.plex/white-square.png</texture>
+                                                <colordiffuse>FFCC7B19</colordiffuse>
+                                            </control>
+                                            <control type="label">
+                                                <posx>194</posx>
+                                                <posy>0</posy>
+                                                <width>50</width>
+                                                <height>38</height>
+                                                <font>font12</font>
+                                                <align>center</align>
+                                                <aligny>center</aligny>
+                                                <textcolor>FF000000</textcolor>
+                                                <label>$INFO[ListItem.Property(unwatched.count)]</label>
                                             </control>
                                         </control>
                                         <control type="label">

--- a/resources/skins/Main/1080i/script-plex-pre_play.xml
+++ b/resources/skins/Main/1080i/script-plex-pre_play.xml
@@ -646,6 +646,44 @@
                                             <colordiffuse>FFCC7B19</colordiffuse>
                                         </control>
                                     </control>
+                                    <control type="image">
+                                        <visible>!String.IsEmpty(ListItem.Property(unwatched))</visible>
+                                        <posx>196</posx>
+                                        <posy>0</posy>
+                                        <width>48</width>
+                                        <height>48</height>
+                                        <texture>script.plex/indicators/unwatched.png</texture>
+                                    </control>
+                                    <control type="group">
+                                        <visible>!String.IsEmpty(ListItem.Property(unwatched.count))</visible>
+                                        <control type="image">
+                                            <posx>193</posx>
+                                            <posy>0</posy>
+                                            <width>51</width>
+                                            <height>39</height>
+                                            <texture>script.plex/white-square.png</texture>
+                                            <colordiffuse>FF000000</colordiffuse>
+                                        </control>
+                                        <control type="image">
+                                            <posx>194</posx>
+                                            <posy>0</posy>
+                                            <width>50</width>
+                                            <height>38</height>
+                                            <texture>script.plex/white-square.png</texture>
+                                            <colordiffuse>FFCC7B19</colordiffuse>
+                                        </control>
+                                        <control type="label">
+                                            <posx>194</posx>
+                                            <posy>0</posy>
+                                            <width>50</width>
+                                            <height>38</height>
+                                            <font>font12</font>
+                                            <align>center</align>
+                                            <aligny>center</aligny>
+                                            <textcolor>FF000000</textcolor>
+                                            <label>$INFO[ListItem.Property(unwatched.count)]</label>
+                                        </control>
+                                    </control>
                                     <control type="label">
                                         <scroll>false</scroll>
                                         <posx>0</posx>
@@ -716,6 +754,44 @@
                                                 <height>8</height>
                                                 <texture>$INFO[ListItem.Property(progress)]</texture>
                                                 <colordiffuse>FFCC7B19</colordiffuse>
+                                            </control>
+                                        </control>
+                                        <control type="image">
+                                            <visible>!String.IsEmpty(ListItem.Property(unwatched))</visible>
+                                            <posx>196</posx>
+                                            <posy>0</posy>
+                                            <width>48</width>
+                                            <height>48</height>
+                                            <texture>script.plex/indicators/unwatched.png</texture>
+                                        </control>
+                                        <control type="group">
+                                            <visible>!String.IsEmpty(ListItem.Property(unwatched.count))</visible>
+                                            <control type="image">
+                                                <posx>193</posx>
+                                                <posy>0</posy>
+                                                <width>51</width>
+                                                <height>39</height>
+                                                <texture>script.plex/white-square.png</texture>
+                                                <colordiffuse>FF000000</colordiffuse>
+                                            </control>
+                                            <control type="image">
+                                                <posx>194</posx>
+                                                <posy>0</posy>
+                                                <width>50</width>
+                                                <height>38</height>
+                                                <texture>script.plex/white-square.png</texture>
+                                                <colordiffuse>FFCC7B19</colordiffuse>
+                                            </control>
+                                            <control type="label">
+                                                <posx>194</posx>
+                                                <posy>0</posy>
+                                                <width>50</width>
+                                                <height>38</height>
+                                                <font>font12</font>
+                                                <align>center</align>
+                                                <aligny>center</aligny>
+                                                <textcolor>FF000000</textcolor>
+                                                <label>$INFO[ListItem.Property(unwatched.count)]</label>
                                             </control>
                                         </control>
                                         <control type="label">

--- a/resources/skins/Main/1080i/script-plex-seasons.xml
+++ b/resources/skins/Main/1080i/script-plex-seasons.xml
@@ -759,6 +759,44 @@
                                             <colordiffuse>FFCC7B19</colordiffuse>
                                         </control>
                                     </control>
+                                    <control type="image">
+                                        <visible>!String.IsEmpty(ListItem.Property(unwatched))</visible>
+                                        <posx>196</posx>
+                                        <posy>0</posy>
+                                        <width>48</width>
+                                        <height>48</height>
+                                        <texture>script.plex/indicators/unwatched.png</texture>
+                                    </control>
+                                    <control type="group">
+                                        <visible>!String.IsEmpty(ListItem.Property(unwatched.count))</visible>
+                                        <control type="image">
+                                            <posx>193</posx>
+                                            <posy>0</posy>
+                                            <width>51</width>
+                                            <height>39</height>
+                                            <texture>script.plex/white-square.png</texture>
+                                            <colordiffuse>FF000000</colordiffuse>
+                                        </control>
+                                        <control type="image">
+                                            <posx>194</posx>
+                                            <posy>0</posy>
+                                            <width>50</width>
+                                            <height>38</height>
+                                            <texture>script.plex/white-square.png</texture>
+                                            <colordiffuse>FFCC7B19</colordiffuse>
+                                        </control>
+                                        <control type="label">
+                                            <posx>194</posx>
+                                            <posy>0</posy>
+                                            <width>50</width>
+                                            <height>38</height>
+                                            <font>font12</font>
+                                            <align>center</align>
+                                            <aligny>center</aligny>
+                                            <textcolor>FF000000</textcolor>
+                                            <label>$INFO[ListItem.Property(unwatched.count)]</label>
+                                        </control>
+                                    </control>
                                     <control type="label">
                                         <scroll>false</scroll>
                                         <posx>0</posx>
@@ -829,6 +867,44 @@
                                                 <height>8</height>
                                                 <texture>$INFO[ListItem.Property(progress)]</texture>
                                                 <colordiffuse>FFCC7B19</colordiffuse>
+                                            </control>
+                                        </control>
+                                        <control type="image">
+                                            <visible>!String.IsEmpty(ListItem.Property(unwatched))</visible>
+                                            <posx>196</posx>
+                                            <posy>0</posy>
+                                            <width>48</width>
+                                            <height>48</height>
+                                            <texture>script.plex/indicators/unwatched.png</texture>
+                                        </control>
+                                        <control type="group">
+                                            <visible>!String.IsEmpty(ListItem.Property(unwatched.count))</visible>
+                                            <control type="image">
+                                                <posx>193</posx>
+                                                <posy>0</posy>
+                                                <width>51</width>
+                                                <height>39</height>
+                                                <texture>script.plex/white-square.png</texture>
+                                                <colordiffuse>FF000000</colordiffuse>
+                                            </control>
+                                            <control type="image">
+                                                <posx>194</posx>
+                                                <posy>0</posy>
+                                                <width>50</width>
+                                                <height>38</height>
+                                                <texture>script.plex/white-square.png</texture>
+                                                <colordiffuse>FFCC7B19</colordiffuse>
+                                            </control>
+                                            <control type="label">
+                                                <posx>194</posx>
+                                                <posy>0</posy>
+                                                <width>50</width>
+                                                <height>38</height>
+                                                <font>font12</font>
+                                                <align>center</align>
+                                                <aligny>center</aligny>
+                                                <textcolor>FF000000</textcolor>
+                                                <label>$INFO[ListItem.Property(unwatched.count)]</label>
                                             </control>
                                         </control>
                                         <control type="label">

--- a/resources/skins/Main/1080i/script-plex-video_player.xml
+++ b/resources/skins/Main/1080i/script-plex-video_player.xml
@@ -417,6 +417,27 @@
                                             <texture background="true">$INFO[ListItem.Thumb]</texture>
                                             <aspectratio>scale</aspectratio>
                                         </control>
+                                        <control type="group">
+                                            <visible>!String.IsEmpty(ListItem.Property(progress))</visible>
+                                            <posx>0</posx>
+                                            <posy>158</posy>
+                                            <control type="image">
+                                                <posx>0</posx>
+                                                <posy>0</posy>
+                                                <width>299</width>
+                                                <height>10</height>
+                                                <texture>script.plex/white-square.png</texture>
+                                                <colordiffuse>C0000000</colordiffuse>
+                                            </control>
+                                            <control type="image">
+                                                <posx>0</posx>
+                                                <posy>1</posy>
+                                                <width>299</width>
+                                                <height>8</height>
+                                                <texture>$INFO[ListItem.Property(progress)]</texture>
+                                                <colordiffuse>FFCC7B19</colordiffuse>
+                                            </control>
+                                        </control>
                                         <control type="label">
                                             <scroll>false</scroll>
                                             <posx>0</posx>
@@ -479,6 +500,27 @@
                                                 <height>168</height>
                                                 <texture background="true">$INFO[ListItem.Thumb]</texture>
                                                 <aspectratio>scale</aspectratio>
+                                            </control>
+                                            <control type="group">
+                                                <visible>!String.IsEmpty(ListItem.Property(progress))</visible>
+                                                <posx>0</posx>
+                                                <posy>158</posy>
+                                                <control type="image">
+                                                    <posx>0</posx>
+                                                    <posy>0</posy>
+                                                    <width>299</width>
+                                                    <height>10</height>
+                                                    <texture>script.plex/white-square.png</texture>
+                                                    <colordiffuse>C0000000</colordiffuse>
+                                                </control>
+                                                <control type="image">
+                                                    <posx>0</posx>
+                                                    <posy>1</posy>
+                                                    <width>299</width>
+                                                    <height>8</height>
+                                                    <texture>$INFO[ListItem.Property(progress)]</texture>
+                                                    <colordiffuse>FFCC7B19</colordiffuse>
+                                                </control>
                                             </control>
                                             <control type="label">
                                                 <scroll>false</scroll>
@@ -596,6 +638,44 @@
                                                 <colordiffuse>FFCC7B19</colordiffuse>
                                             </control>
                                         </control>
+                                        <control type="image">
+                                            <visible>!String.IsEmpty(ListItem.Property(unwatched))</visible>
+                                            <posx>196</posx>
+                                            <posy>0</posy>
+                                            <width>48</width>
+                                            <height>48</height>
+                                            <texture>script.plex/indicators/unwatched.png</texture>
+                                        </control>
+                                        <control type="group">
+                                            <visible>!String.IsEmpty(ListItem.Property(unwatched.count))</visible>
+                                            <control type="image">
+                                                <posx>193</posx>
+                                                <posy>0</posy>
+                                                <width>51</width>
+                                                <height>39</height>
+                                                <texture>script.plex/white-square.png</texture>
+                                                <colordiffuse>FF000000</colordiffuse>
+                                            </control>
+                                            <control type="image">
+                                                <posx>194</posx>
+                                                <posy>0</posy>
+                                                <width>50</width>
+                                                <height>38</height>
+                                                <texture>script.plex/white-square.png</texture>
+                                                <colordiffuse>FFCC7B19</colordiffuse>
+                                            </control>
+                                            <control type="label">
+                                                <posx>194</posx>
+                                                <posy>0</posy>
+                                                <width>50</width>
+                                                <height>38</height>
+                                                <font>font12</font>
+                                                <align>center</align>
+                                                <aligny>center</aligny>
+                                                <textcolor>FF000000</textcolor>
+                                                <label>$INFO[ListItem.Property(unwatched.count)]</label>
+                                            </control>
+                                        </control>
                                         <control type="label">
                                             <scroll>false</scroll>
                                             <posx>0</posx>
@@ -666,6 +746,44 @@
                                                     <height>8</height>
                                                     <texture>$INFO[ListItem.Property(progress)]</texture>
                                                     <colordiffuse>FFCC7B19</colordiffuse>
+                                                </control>
+                                            </control>
+                                            <control type="image">
+                                                <visible>!String.IsEmpty(ListItem.Property(unwatched))</visible>
+                                                <posx>196</posx>
+                                                <posy>0</posy>
+                                                <width>48</width>
+                                                <height>48</height>
+                                                <texture>script.plex/indicators/unwatched.png</texture>
+                                            </control>
+                                            <control type="group">
+                                                <visible>!String.IsEmpty(ListItem.Property(unwatched.count))</visible>
+                                                <control type="image">
+                                                    <posx>193</posx>
+                                                    <posy>0</posy>
+                                                    <width>51</width>
+                                                    <height>39</height>
+                                                    <texture>script.plex/white-square.png</texture>
+                                                    <colordiffuse>FF000000</colordiffuse>
+                                                </control>
+                                                <control type="image">
+                                                    <posx>194</posx>
+                                                    <posy>0</posy>
+                                                    <width>50</width>
+                                                    <height>38</height>
+                                                    <texture>script.plex/white-square.png</texture>
+                                                    <colordiffuse>FFCC7B19</colordiffuse>
+                                                </control>
+                                                <control type="label">
+                                                    <posx>194</posx>
+                                                    <posy>0</posy>
+                                                    <width>50</width>
+                                                    <height>38</height>
+                                                    <font>font12</font>
+                                                    <align>center</align>
+                                                    <aligny>center</aligny>
+                                                    <textcolor>FF000000</textcolor>
+                                                    <label>$INFO[ListItem.Property(unwatched.count)]</label>
                                                 </control>
                                             </control>
                                             <control type="label">


### PR DESCRIPTION
GHI (If applicable): #232 

## Description:
- adds the unwatched marker and progress indicators for related items in preplay, episodes and postplay windows.
- postplay window: adds progress indicators to onDeck items 
- postplay window: fixes the display of the related items header in certain cases

## Checklist:
- [x] I have based this PR against the develop branch
