### PR TITLE
Add support for Plex Relay service

### DIFF
--- a/lib/_included_packages/plexnet/myplexmanager.py
+++ b/lib/_included_packages/plexnet/myplexmanager.py
@@ -32,6 +32,7 @@ class MyPlexManager(object):
 
         if plexapp.ACCOUNT.isSecure:
             request.addParam("includeHttps", "1")
+            request.addParam("includeRelay", "1")
 
         plexapp.APP.startRequest(request, context)
 

--- a/lib/_included_packages/plexnet/plexresource.py
+++ b/lib/_included_packages/plexnet/plexresource.py
@@ -6,7 +6,7 @@ import plexobjects
 import plexconnection
 import util
 
-RESOURCES = 'https://plex.tv/api/resources?includeHttps=1'
+RESOURCES = 'https://plex.tv/api/resources?includeHttps=1&includeRelay=1'
 
 
 class PlexResource(object):


### PR DESCRIPTION
## Description:
Add support for Plex Relay service.
The change to myplexmanager.py might be sufficient - but both done to keep things consistent.
This is an imported module - so probably best to put the change into the original source but not found it

## Checklist:
- [x] I have based this PR against the develop branch
- [ ] Without this change, Plex for Kodi cannot connect via the Plex Relay service