### PR TITLE
Add advanced setting to go back instantly instead of showing the header in scrolled views

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -468,6 +468,7 @@ class AdvancedSettings(object):
         ("kodi_skip_stepping", False),
         ("auto_seek", True),
         ("dynamic_timeline_seek", False),
+        ("fast_back", False),
     )
 
     def __init__(self):

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -199,7 +199,9 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
                         return
 
             elif action == xbmcgui.ACTION_NAV_BACK:
-                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) or not controlID:
+                if (not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(
+                        self.OPTIONS_GROUP_ID)) or not controlID) and \
+                        not util.advancedSettings.fastBack:
                     if self.getProperty('on.extras'):
                         self.setFocusId(self.OPTIONS_GROUP_ID)
                         return

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -437,37 +437,39 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
                     self.hubItemClicked(controlID, auto_play=True)
                     return
 
-            if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
-                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) \
-                        and util.getGlobalProperty('off.sections'):
-                    self.lastNonOptionsFocusID = self.lastFocusID
-                    self.setFocusId(self.OPTIONS_GROUP_ID)
-                    return
-                elif not action == xbmcgui.ACTION_NAV_BACK \
-                        and xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) \
-                        and util.getGlobalProperty('off.sections') and self.lastNonOptionsFocusID:
-                    self.setFocusId(self.lastNonOptionsFocusID)
-                    self.lastNonOptionsFocusID = None
-                    return
+            if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_PREVIOUS_MENU, xbmcgui.ACTION_CONTEXT_MENU):
+                if action in (xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_PREVIOUS_MENU):
+                    if self.getFocusId() == self.USER_LIST_ID:
+                        self.setFocusId(self.USER_BUTTON_ID)
+                        return
+                    elif self.getFocusId() == self.SERVER_LIST_ID:
+                        self.setFocusId(self.SERVER_BUTTON_ID)
+                        return
 
-            if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_PREVIOUS_MENU):
-                if self.getFocusId() == self.USER_LIST_ID:
-                    self.setFocusId(self.USER_BUTTON_ID)
-                    return
-                elif self.getFocusId() == self.SERVER_LIST_ID:
-                    self.setFocusId(self.SERVER_BUTTON_ID)
-                    return
+                    if util.advancedSettings.fastBack and self.lastSection != HomeSection and \
+                            self.lastFocusID != self.SECTION_LIST_ID:
+                        self.setProperty('hub.focus', '0')
+                        self.sectionList.selectItem(0)
+                        self.lastSection = HomeSection
+                        self.setFocusId(self.SECTION_LIST_ID)
+                        self._sectionReallyChanged()
+                        return
 
-                if util.advancedSettings.fastBack and self.lastSection != HomeSection and \
-                        self.lastFocusID != self.SECTION_LIST_ID:
-                    self.setProperty('hub.focus', '0')
-                    self.sectionList.selectItem(0)
-                    self.lastSection = HomeSection
-                    self.setFocusId(self.SECTION_LIST_ID)
-                    self._sectionReallyChanged()
-                    return
+                if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
+                    if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) \
+                            and util.getGlobalProperty('off.sections')\
+                            and (not util.advancedSettings.fastBack or action == xbmcgui.ACTION_CONTEXT_MENU):
+                        self.lastNonOptionsFocusID = self.lastFocusID
+                        self.setFocusId(self.OPTIONS_GROUP_ID)
+                        return
+                    elif action == xbmcgui.ACTION_CONTEXT_MENU \
+                            and xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) \
+                            and util.getGlobalProperty('off.sections') and self.lastNonOptionsFocusID:
+                        self.setFocusId(self.lastNonOptionsFocusID)
+                        self.lastNonOptionsFocusID = None
+                        return
 
-                if not self.confirmExit():
+                if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_PREVIOUS_MENU) and not self.confirmExit():
                     return
         except:
             util.ERROR()

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -458,8 +458,8 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
                     self.setFocusId(self.SERVER_BUTTON_ID)
                     return
 
-                if util.advancedSettings.fastBack and action != xbmcgui.ACTION_CONTEXT_MENU and \
-                        self.lastSection != HomeSection and self.lastFocusID != self.SECTION_LIST_ID:
+                if util.advancedSettings.fastBack and self.lastSection != HomeSection and \
+                        self.lastFocusID != self.SECTION_LIST_ID:
                     self.setProperty('hub.focus', '0')
                     self.sectionList.selectItem(0)
                     self.lastSection = HomeSection

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -460,10 +460,11 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
 
                 if util.advancedSettings.fastBack and action != xbmcgui.ACTION_CONTEXT_MENU and \
                         self.lastSection != HomeSection and self.lastFocusID != self.SECTION_LIST_ID:
+                    self.setProperty('hub.focus', '0')
                     self.sectionList.selectItem(0)
                     self.lastSection = HomeSection
-                    self.sectionChanged(True)
                     self.setFocusId(self.SECTION_LIST_ID)
+                    self._sectionReallyChanged()
                     return
 
                 if not self.confirmExit():

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -458,6 +458,14 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
                     self.setFocusId(self.SERVER_BUTTON_ID)
                     return
 
+                if util.advancedSettings.fastBack and action != xbmcgui.ACTION_CONTEXT_MENU and \
+                        self.lastSection != HomeSection and self.lastFocusID != self.SECTION_LIST_ID:
+                    self.sectionList.selectItem(0)
+                    self.lastSection = HomeSection
+                    self.sectionChanged(True)
+                    self.setFocusId(self.SECTION_LIST_ID)
+                    return
+
                 if not self.confirmExit():
                     return
         except:

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -438,6 +438,8 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
                     return
 
             if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_PREVIOUS_MENU, xbmcgui.ACTION_CONTEXT_MENU):
+                optionsFocused = xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID))
+                offSections = util.getGlobalProperty('off.sections')
                 if action in (xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_PREVIOUS_MENU):
                     if self.getFocusId() == self.USER_LIST_ID:
                         self.setFocusId(self.USER_BUTTON_ID)
@@ -446,25 +448,21 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
                         self.setFocusId(self.SERVER_BUTTON_ID)
                         return
 
-                    if util.advancedSettings.fastBack and self.lastSection != HomeSection and \
-                            self.lastFocusID != self.SECTION_LIST_ID:
+                    if util.advancedSettings.fastBack and not optionsFocused and offSections \
+                            and self.lastFocusID not in (self.USER_BUTTON_ID, self.SERVER_BUTTON_ID,
+                                                         self.SEARCH_BUTTON_ID, self.SECTION_LIST_ID):
                         self.setProperty('hub.focus', '0')
-                        self.sectionList.selectItem(0)
-                        self.lastSection = HomeSection
                         self.setFocusId(self.SECTION_LIST_ID)
-                        self._sectionReallyChanged()
                         return
 
                 if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
-                    if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) \
-                            and util.getGlobalProperty('off.sections')\
+                    if not optionsFocused and offSections \
                             and (not util.advancedSettings.fastBack or action == xbmcgui.ACTION_CONTEXT_MENU):
                         self.lastNonOptionsFocusID = self.lastFocusID
                         self.setFocusId(self.OPTIONS_GROUP_ID)
                         return
-                    elif action == xbmcgui.ACTION_CONTEXT_MENU \
-                            and xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) \
-                            and util.getGlobalProperty('off.sections') and self.lastNonOptionsFocusID:
+                    elif action == xbmcgui.ACTION_CONTEXT_MENU and optionsFocused and offSections \
+                            and self.lastNonOptionsFocusID:
                         self.setFocusId(self.lastNonOptionsFocusID)
                         self.lastNonOptionsFocusID = None
                         return

--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -521,7 +521,8 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
                         return
 
             elif action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
-                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)):
+                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) and \
+                        (not util.advancedSettings.fastBack or action == xbmcgui.ACTION_CONTEXT_MENU):
                     if xbmc.getCondVisibility('Integer.IsGreater(Container(101).ListItem.Property(index),5)'):
                         self.setFocusId(self.OPTIONS_GROUP_ID)
                         return

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -100,7 +100,9 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
                 self.setFocusId(self.lastFocusID)
 
             if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
-                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)):
+                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(
+                        self.OPTIONS_GROUP_ID)) and \
+                        (not util.advancedSettings.fastBack or action == xbmcgui.ACTION_CONTEXT_MENU):
                     if self.getProperty('on.extras'):
                         self.lastNonOptionsFocusID = self.lastFocusID
                         self.setFocusId(self.OPTIONS_GROUP_ID)

--- a/lib/windows/subitems.py
+++ b/lib/windows/subitems.py
@@ -178,7 +178,9 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
                         return
 
             elif action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
-                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)):
+                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(
+                        self.OPTIONS_GROUP_ID)) and \
+                        (not util.advancedSettings.fastBack or action == xbmcgui.ACTION_CONTEXT_MENU):
                     if self.getProperty('on.extras'):
                         self.setFocusId(self.OPTIONS_GROUP_ID)
                         return

--- a/lib/windows/videoplayer.py
+++ b/lib/windows/videoplayer.py
@@ -99,9 +99,10 @@ class VideoPlayerWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
                 self.resetPassoutProtection()
                 if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
                     if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)):
-                        self.lastNonOptionsFocusID = self.lastFocusID
-                        self.setFocusId(self.OPTIONS_GROUP_ID)
-                        return
+                        if not util.advancedSettings.fastBack or action == xbmcgui.ACTION_CONTEXT_MENU:
+                            self.lastNonOptionsFocusID = self.lastFocusID
+                            self.setFocusId(self.OPTIONS_GROUP_ID)
+                            return
                     else:
                         if self.lastNonOptionsFocusID:
                             self.setFocusId(self.lastNonOptionsFocusID)

--- a/lib/windows/videoplayer.py
+++ b/lib/windows/videoplayer.py
@@ -104,7 +104,7 @@ class VideoPlayerWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
                             self.setFocusId(self.OPTIONS_GROUP_ID)
                             return
                     else:
-                        if self.lastNonOptionsFocusID:
+                        if self.lastNonOptionsFocusID and action == xbmcgui.ACTION_CONTEXT_MENU:
                             self.setFocusId(self.lastNonOptionsFocusID)
                             self.lastNonOptionsFocusID = None
                             return

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -963,6 +963,14 @@ msgctxt "#32466"
 msgid "Automatically seek selected position after a delay"
 msgstr ""
 
+msgctxt "#32467"
+msgid "User Interface"
+msgstr ""
+
 msgctxt "#32471"
 msgid "Use Plex/Kodi steps for timeline"
+msgstr ""
+
+msgctxt "#32485"
+msgid "Go back instantly with the previous menu action in scrolled views"
 msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -962,6 +962,14 @@ msgctxt "#32466"
 msgid "Automatically seek to the selected timeline position after a second"
 msgstr "Nach Verzögerung automatisch zur aktuell gewählten Position springen"
 
+msgctxt "#32467"
+msgid "User Interface"
+msgstr "Benutzeroberfläche"
+
 msgctxt "#32471"
 msgid "Use Plex/Kodi steps for timeline"
 msgstr "Plex/Kodi-Skip-Schritte für die Zeitachse verwenden"
+
+msgctxt "#32485"
+msgid "Go back instantly with the previous menu action in scrolled views"
+msgstr "Mit der Previous-Menu-Aktion In gescrollten Ansichten sofort zurückgehen"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -13,4 +13,7 @@
     <setting id="kodi_skip_stepping" type="bool" label="32465" default="false" />
     <setting id="dynamic_timeline_seek" type="bool" label="32471" default="false" />
   </category>
+  <category label="32467">
+    <setting id="fast_back" type="bool" label="32485" default="false" />
+  </category>
 </settings>


### PR DESCRIPTION

GHI (If applicable): #

## Description:
Adds an advanced setting that changes the behaviour of the ACTION_PREVIOUS_MENU to instantly go back instead of showing the menu bar in scrolled views.

## Checklist:
- [x] I have based this PR against the develop branch
