### PR TITLE
Change ACTION_PREVIOUS_MENU handling when sections are highlighted

### DIFF
--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -437,11 +437,18 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
                     return
 
             if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
-                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) and self.getProperty('off.sections'):
+                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) and \
+                        self.getProperty('off.sections'):
                     self.setFocusId(self.OPTIONS_GROUP_ID)
                     return
 
-            if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_PREVIOUS_MENU):
+                # highlight the home hub if a section is currently focused
+                if self.lastSection != HomeSection and self.lastFocusID == self.SECTION_LIST_ID:
+                    self.sectionList.selectItem(0)
+                    self.lastSection = HomeSection
+                    self.sectionChanged(True)
+                    return
+
                 if self.getFocusId() == self.USER_LIST_ID:
                     self.setFocusId(self.USER_BUTTON_ID)
                     return


### PR DESCRIPTION
GHI (If applicable): #

## Description:
Show the home hub instead of showing the exit confirmation when using ACTION_PREVIOUS_MENU with a section highlighted in the top bar in the home view.

## Checklist:
- [x] I have based this PR against the develop branch
