### PR TITLE
Fix resume under certain circumstances

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -388,7 +388,8 @@ class SeekPlayerHandler(BasePlayerHandler):
             track = self.player.video.selectedAudioStream()
             if track:
                 try:
-                    currIdx = kodijsonrpc.rpc.Player.GetProperties(playerid=1, properties=['currentaudiostream'])['currentaudiostream']['index']
+                    playerID = kodijsonrpc.rpc.Player.GetActivePlayers()[0]["playerid"]
+                    currIdx = kodijsonrpc.rpc.Player.GetProperties(playerid=playerID, properties=['currentaudiostream'])['currentaudiostream']['index']
                     if currIdx == track.typeIndex:
                         util.DEBUG_LOG('Audio track is correct index: {0}'.format(track.typeIndex))
                         return

--- a/lib/player.py
+++ b/lib/player.py
@@ -406,11 +406,11 @@ class SeekPlayerHandler(BasePlayerHandler):
     def initPlayback(self):
         self.seeking = self.NO_SEEK
 
-        if self.mode == self.MODE_ABSOLUTE:
-            self.seekAbsolute()
-
         self.setSubtitles()
         self.setAudioTrack()
+
+        if self.mode == self.MODE_ABSOLUTE:
+            self.seekAbsolute()
 
     def onPlayBackFailed(self):
         util.DEBUG_LOG('SeekHandler: onPlayBackFailed - Seeking={0}'.format(self.seeking))


### PR DESCRIPTION
GHI (If applicable): #

## Description:
On my OSMC Kodi it seems like the active video player has the ID 0, not 1 as assumed by `player.py` (this must have changed recently with an OSMC update). This results in resume to not work:
```
16:45:33.145 T:2817839872   ERROR: _________________________________________________________________________________
16:45:33.145 T:2817839872   ERROR: script.plex: ERROR:
16:45:33.145 T:2817839872   ERROR:     Traceback (most recent call last):
16:45:33.145 T:2817839872   ERROR:       File "/home/osmc/.kodi/addons/script.plex/lib/player.py", line 392, in setAudioTrack
16:45:33.145 T:2817839872   ERROR:         currIdx = kodijsonrpc.rpc.Player.GetProperties(playerid=1, properties=['currentaudiostream'])['currentaudiostream']['index']
16:45:33.145 T:2817839872   ERROR:       File "/home/osmc/.kodi/addons/script.plex/lib/kodijsonrpc.py", line 29, in handler
16:45:33.145 T:2817839872   ERROR:         raise self.Exception(ret['error'])
16:45:33.145 T:2817839872   ERROR:     Exception: {u'message': u'Failed to execute method.', u'code': -32100}
16:45:33.145 T:2817839872   ERROR: _________________________________________________________________________________
16:45:33.146 T:2817839872   ERROR: `
16:45:33.240 T:3197907712  NOTICE: Closing stream player 3
16:45:33.240 T:3197907712  NOTICE: Opening stream: 0 source: 1024
16:45:33.246 T:2817839872  NOTICE: script.plex: Switching audio track - index: 0
16:45:33.519 T:3197907712  NOTICE: Closing stream player 1
16:45:33.520 T:3197907712  NOTICE: Waiting for audio thread to exit
16:45:33.520 T:2742465280  NOTICE: thread end: CVideoPlayerAudio::OnExit()
16:45:33.520 T:3197907712  NOTICE: Closing audio device
16:45:33.521 T:3197907712  NOTICE: Deleting audio codec
16:45:33.521 T:3197907712  NOTICE: Opening stream: 0 source: 256
16:45:33.521 T:3197907712  NOTICE: Finding audio codec for: 86018
16:45:33.523 T:3197907712  NOTICE: Creating audio thread
16:45:33.524 T:2742465280  NOTICE: running thread: CVideoPlayerAudio::Process()
16:45:33.605 T:2742465280  NOTICE: Creating audio stream (codec id: 86018, channels: 2, sample rate: 44100, no pass-through)
```

## Checklist:
- [x] I have based this PR against the develop branch
