### PR TITLE
Allow closing of the options header in scrolled views using ACTION_CONTEXT_MENU

### DIFF
--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -90,6 +90,7 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.parentList = kwargs.get('parentList')
         self.lastItem = None
         self.lastFocusID = None
+        self.lastNonOptionsFocusID = None
         self.tasks = backgroundthread.Tasks()
 
     def reset(self, episode, season=None, show=None):
@@ -188,9 +189,16 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
                 return
             elif action == xbmcgui.ACTION_CONTEXT_MENU:
                 if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)):
+                    self.lastNonOptionsFocusID = self.lastFocusID
                     self.setFocusId(self.OPTIONS_GROUP_ID)
                     return
-            elif action in (xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
+                else:
+                    if self.lastNonOptionsFocusID:
+                        self.setFocusId(self.lastNonOptionsFocusID)
+                        self.lastNonOptionsFocusID = None
+                        return
+
+            elif action == xbmcgui.ACTION_NAV_BACK:
                 if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) or not controlID:
                     if self.getProperty('on.extras'):
                         self.setFocusId(self.OPTIONS_GROUP_ID)

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -438,12 +438,14 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
                     return
 
             if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
-                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) and self.getProperty('off.sections'):
+                if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) \
+                        and util.getGlobalProperty('off.sections'):
                     self.lastNonOptionsFocusID = self.lastFocusID
                     self.setFocusId(self.OPTIONS_GROUP_ID)
                     return
-                elif xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) \
-                        and self.getProperty('off.sections') and self.lastNonOptionsFocusID:
+                elif not action == xbmcgui.ACTION_NAV_BACK \
+                        and xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) \
+                        and util.getGlobalProperty('off.sections') and self.lastNonOptionsFocusID:
                     self.setFocusId(self.lastNonOptionsFocusID)
                     self.lastNonOptionsFocusID = None
                     return

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -306,6 +306,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         self.sectionChangeThread = None
         self.sectionChangeTimeout = 0
         self.lastFocusID = None
+        self.lastNonOptionsFocusID = None
         self.sectionHubs = {}
         self.updateHubs = {}
         windowutils.HOME = self
@@ -438,7 +439,13 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
 
             if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
                 if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) and self.getProperty('off.sections'):
+                    self.lastNonOptionsFocusID = self.lastFocusID
                     self.setFocusId(self.OPTIONS_GROUP_ID)
+                    return
+                elif xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) \
+                        and self.getProperty('off.sections') and self.lastNonOptionsFocusID:
+                    self.setFocusId(self.lastNonOptionsFocusID)
+                    self.lastNonOptionsFocusID = None
                     return
 
             if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_PREVIOUS_MENU):

--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -400,6 +400,8 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
         self.showPanelControl = None
         self.keyListControl = None
         self.lastItem = None
+        self.lastFocusID = None
+        self.lastNonOptionsFocusID = None
 
         self.dcpjPos = 0
         self.dcpjThread = None
@@ -509,8 +511,15 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
                 self.onMouseDrag(action)
             elif action == xbmcgui.ACTION_CONTEXT_MENU:
                 if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)):
+                    self.lastNonOptionsFocusID = self.lastFocusID
                     self.setFocusId(self.OPTIONS_GROUP_ID)
                     return
+                else:
+                    if self.lastNonOptionsFocusID:
+                        self.setFocusId(self.lastNonOptionsFocusID)
+                        self.lastNonOptionsFocusID = None
+                        return
+
             elif action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
                 if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)):
                     if xbmc.getCondVisibility('Integer.IsGreater(Container(101).ListItem.Property(index),5)'):
@@ -551,6 +560,8 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
             self.searchButtonClicked()
 
     def onFocus(self, controlID):
+        self.lastFocusID = controlID
+
         if controlID == self.KEY_LIST_ID:
             self.selectKey()
 

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -64,6 +64,7 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.exitCommand = None
         self.trailer = None
         self.lastFocusID = None
+        self.lastNonOptionsFocusID = None
 
     def onFirstInit(self):
         self.extraListControl = kodigui.ManagedControlList(self, self.EXTRA_LIST_ID, 5)
@@ -101,8 +102,14 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
             if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
                 if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)):
                     if self.getProperty('on.extras'):
+                        self.lastNonOptionsFocusID = self.lastFocusID
                         self.setFocusId(self.OPTIONS_GROUP_ID)
                         return
+                elif xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)) \
+                        and self.getProperty('on.extras') and self.lastNonOptionsFocusID:
+                    self.setFocusId(self.lastNonOptionsFocusID)
+                    self.lastNonOptionsFocusID = None
+                    return
 
             if action == xbmcgui.ACTION_LAST_PAGE and xbmc.getCondVisibility('ControlGroup(300).HasFocus(0)'):
                 self.next()

--- a/lib/windows/subitems.py
+++ b/lib/windows/subitems.py
@@ -77,6 +77,7 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.mediaItems = None
         self.exitCommand = None
         self.lastFocusID = None
+        self.lastNonOptionsFocusID = None
 
     def onFirstInit(self):
         self.subItemListControl = kodigui.ManagedControlList(self, self.SUB_ITEM_LIST_ID, 5)
@@ -167,8 +168,15 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
 
             if action == xbmcgui.ACTION_CONTEXT_MENU:
                 if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)):
+                    self.lastNonOptionsFocusID = self.lastFocusID
                     self.setFocusId(self.OPTIONS_GROUP_ID)
                     return
+                else:
+                    if self.lastNonOptionsFocusID:
+                        self.setFocusId(self.lastNonOptionsFocusID)
+                        self.lastNonOptionsFocusID = None
+                        return
+
             elif action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
                 if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)):
                     if self.getProperty('on.extras'):

--- a/lib/windows/videoplayer.py
+++ b/lib/windows/videoplayer.py
@@ -67,6 +67,8 @@ class VideoPlayerWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         self.aborted = True
         self.timeout = None
         self.passoutProtection = 0
+        self.lastFocusID = None
+        self.lastNonOptionsFocusID = None
 
     def doClose(self):
         util.DEBUG_LOG('VideoPlayerWindow: Closing')
@@ -97,8 +99,14 @@ class VideoPlayerWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
                 self.resetPassoutProtection()
                 if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_CONTEXT_MENU):
                     if not xbmc.getCondVisibility('ControlGroup({0}).HasFocus(0)'.format(self.OPTIONS_GROUP_ID)):
+                        self.lastNonOptionsFocusID = self.lastFocusID
                         self.setFocusId(self.OPTIONS_GROUP_ID)
                         return
+                    else:
+                        if self.lastNonOptionsFocusID:
+                            self.setFocusId(self.lastNonOptionsFocusID)
+                            self.lastNonOptionsFocusID = None
+                            return
 
                 if action in(xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_PREVIOUS_MENU):
                     self.doClose()
@@ -141,6 +149,8 @@ class VideoPlayerWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
     def onFocus(self, controlID):
         if not self.postPlayMode:
             return
+
+        self.lastFocusID = controlID
 
         if 399 < controlID < 500:
             self.setProperty('hub.focus', str(controlID - 400))


### PR DESCRIPTION

GHI (If applicable): #

## Description:
The options header can be opened using ACTION_CONTEXT_MENU, but not be closed the same way. Normally Kodi context menus can be closed again with the same button.

## Checklist:
- [x] I have based this PR against the develop branch
