### PR TITLE
Conditional re-pause on video settings changed

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -623,6 +623,7 @@ class PlexPlayer(xbmc.Player, signalsmixin.SignalsMixin):
         self._closed = False
         self._nextItem = None
         self.started = False
+        self.pauseAfterPlaybackStarted = False
         self.video = None
         self.hasOSD = False
         self.hasSeekOSD = False
@@ -647,6 +648,7 @@ class PlexPlayer(xbmc.Player, signalsmixin.SignalsMixin):
         self.video = None
         self.started = False
         self.playerObject = None
+        self.pauseAfterPlaybackStarted = False
         self.handler = AudioPlayerHandler(self)
         self.currentTime = 0
 
@@ -873,6 +875,10 @@ class PlexPlayer(xbmc.Player, signalsmixin.SignalsMixin):
 
     def onPlayBackStarted(self):
         self.started = True
+        if self.pauseAfterPlaybackStarted:
+            self.control('pause')
+            self.pauseAfterPlaybackStarted = False
+
         util.DEBUG_LOG('Player - STARTED')
         self.trigger('playback.started')
         if not self.handler:

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -664,7 +664,10 @@ class SeekDialog(kodigui.BaseDialog):
             self.handler.seek(self.selectedOffset if offset is None else offset, settings_changed=settings_changed)
 
             if state_before_seek == self.player.STATE_PAUSED:
-                self.player.control("pause")
+                if not settings_changed:
+                    self.player.control("pause")
+                else:
+                    self.player.pauseAfterPlaybackStarted = True
         finally:
             self._seeking = False
             self._seekingWithoutOSD = False


### PR DESCRIPTION

GHI (If applicable): #

## Description:
When settings are changed for a video that's paused, re-pause the video after reloading the player to keep the state consistent.

## Checklist:
- [x] I have based this PR against the develop branch
