### PR TITLE
Fix connection handling; shutdown properly with hanging connection

### DIFF
--- a/lib/_included_packages/plexnet/asyncadapter.py
+++ b/lib/_included_packages/plexnet/asyncadapter.py
@@ -114,6 +114,7 @@ class AsyncVerifiedHTTPSConnection(VerifiedHTTPSConnection):
             except socket.error as _:
                 err = _
                 if sock is not None:
+                    sock.shutdown(socket.SHUT_RDWR)
                     sock.close()
 
         if err is not None:

--- a/lib/main.py
+++ b/lib/main.py
@@ -31,11 +31,11 @@ def waitForThreads():
                     util.DEBUG_LOG('Main: Waiting on: {0}...'.format(t.name))
                     if isinstance(t, threading._Timer):
                         t.cancel()
+
+                    try:
                         t.join()
-                    elif isinstance(t, threadutils.KillableThread):
-                        t.kill(force_and_wait=True)
-                    else:
-                        t.join()
+                    except RuntimeError:
+                        pass
 
 
 @atexit.register


### PR DESCRIPTION
GHI (If applicable): #

## Description:
- correctly shuts down the socket of `AsyncVerifiedHTTPSConnection` before closing it
- fixes an issue when shutting down the application. `waitForThreads` can end up with an infinite loop as `KillableThread.kill` doesn't do anything

## Checklist:
- [x] I have based this PR against the develop branch
