### PR TITLE
Adjust track number display for audio playlists with more than 999 items

### DIFF
--- a/resources/skins/Main/1080i/script-plex-music_current_playlist.xml
+++ b/resources/skins/Main/1080i/script-plex-music_current_playlist.xml
@@ -151,17 +151,17 @@
                                 <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
-                                <width>50</width>
+                                <width>70</width>
                                 <height>100</height>
                                 <font>font10</font>
-                                <align>left</align>
+                                <align>center</align>
                                 <aligny>center</aligny>
                                 <textcolor>D8FFFFFF</textcolor>
                                 <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                             </control>
                             <control type="image">
                                 <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                <posx>0</posx>
+                                <posx>18</posx>
                                 <posy>32.5</posy>
                                 <width>35</width>
                                 <height>35</height>
@@ -169,7 +169,7 @@
                                 <colordiffuse>FFE5A00D</colordiffuse>
                             </control>
                             <control type="image">
-                                <posx>63</posx>
+                                <posx>83</posx>
                                 <posy>11</posy>
                                 <width>74</width>
                                 <height>74</height>
@@ -177,12 +177,12 @@
                                 <aspectratio>scale</aspectratio>
                             </control>
                             <control type="group">
-                                <posx>168</posx>
+                                <posx>188</posx>
                                 <posy>0</posy>
                                 <control type="label">
                                     <posx>0</posx>
                                     <posy>15</posy>
-                                    <width>723</width>
+                                    <width>683</width>
                                     <height>30</height>
                                     <font>font10</font>
                                     <align>left</align>
@@ -193,7 +193,7 @@
                                 <control type="label">
                                     <posx>0</posx>
                                     <posy>50</posy>
-                                    <width>723</width>
+                                    <width>683</width>
                                     <height>30</height>
                                     <font>font10</font>
                                     <align>left</align>
@@ -236,10 +236,10 @@
                                     <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>0</posx>
                                     <posy>0</posy>
-                                    <width>50</width>
+                                    <width>70</width>
                                     <height>100</height>
                                     <font>font10</font>
-                                    <align>left</align>
+                                    <align>center</align>
                                     <aligny>center</aligny>
                                     <textcolor>D8FFFFFF</textcolor>
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
@@ -254,7 +254,7 @@
                                     <colordiffuse>FFE5A00D</colordiffuse>
                                 </control>
                                 <control type="image">
-                                    <posx>63</posx>
+                                    <posx>83</posx>
                                     <posy>11</posy>
                                     <width>74</width>
                                     <height>74</height>
@@ -262,12 +262,12 @@
                                     <aspectratio>scale</aspectratio>
                                 </control>
                                 <control type="group">
-                                    <posx>168</posx>
+                                    <posx>188</posx>
                                     <posy>0</posy>
                                     <control type="label">
                                         <posx>0</posx>
                                         <posy>15</posy>
-                                        <width>723</width>
+                                        <width>683</width>
                                         <height>30</height>
                                         <font>font10</font>
                                         <align>left</align>
@@ -278,7 +278,7 @@
                                     <control type="label">
                                         <posx>0</posx>
                                         <posy>50</posy>
-                                        <width>723</width>
+                                        <width>683</width>
                                         <height>30</height>
                                         <font>font10</font>
                                         <align>left</align>

--- a/resources/skins/Main/1080i/script-plex-playlist.xml
+++ b/resources/skins/Main/1080i/script-plex-playlist.xml
@@ -158,17 +158,17 @@
                                 <visible>String.IsEmpty(ListItem.Property(track.ID)) | !StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
-                                <width>50</width>
+                                <width>70</width>
                                 <height>100</height>
                                 <font>font10</font>
-                                <align>left</align>
+                                <align>center</align>
                                 <aligny>center</aligny>
                                 <textcolor>D8FFFFFF</textcolor>
                                 <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                             </control>
                             <control type="image">
                                 <visible>!String.IsEmpty(ListItem.Property(track.ID)) + StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                <posx>0</posx>
+                                <posx>18</posx>
                                 <posy>32.5</posy>
                                 <width>35</width>
                                 <height>35</height>
@@ -178,7 +178,7 @@
                             <control type="group">
                                 <visible>String.IsEmpty(ListItem.Property(video))</visible>
                                 <control type="image">
-                                    <posx>63</posx>
+                                    <posx>83</posx>
                                     <posy>11</posy>
                                     <width>74</width>
                                     <height>74</height>
@@ -186,12 +186,12 @@
                                     <aspectratio>scale</aspectratio>
                                 </control>
                                 <control type="group">
-                                    <posx>168</posx>
+                                    <posx>208</posx>
                                     <posy>0</posy>
                                     <control type="label">
                                         <posx>0</posx>
                                         <posy>15</posy>
-                                        <width>692</width>
+                                        <width>652</width>
                                         <height>30</height>
                                         <font>font10</font>
                                         <align>left</align>
@@ -202,7 +202,7 @@
                                     <control type="label">
                                         <posx>0</posx>
                                         <posy>50</posy>
-                                        <width>692</width>
+                                        <width>652</width>
                                         <height>30</height>
                                         <font>font10</font>
                                         <align>left</align>
@@ -291,10 +291,10 @@
                                     <visible>String.IsEmpty(ListItem.Property(track.ID)) | !StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>0</posx>
                                     <posy>0</posy>
-                                    <width>50</width>
+                                    <width>70</width>
                                     <height>100</height>
                                     <font>font10</font>
-                                    <align>left</align>
+                                    <align>center</align>
                                     <aligny>center</aligny>
                                     <textcolor>D8FFFFFF</textcolor>
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
@@ -311,7 +311,7 @@
                                 <control type="group">
                                     <visible>String.IsEmpty(ListItem.Property(video))</visible>
                                     <control type="image">
-                                        <posx>63</posx>
+                                        <posx>83</posx>
                                         <posy>11</posy>
                                         <width>74</width>
                                         <height>74</height>
@@ -319,12 +319,12 @@
                                         <aspectratio>scale</aspectratio>
                                     </control>
                                     <control type="group">
-                                        <posx>168</posx>
+                                        <posx>208</posx>
                                         <posy>0</posy>
                                         <control type="label">
                                             <posx>0</posx>
                                             <posy>15</posy>
-                                            <width>692</width>
+                                            <width>652</width>
                                             <height>30</height>
                                             <font>font10</font>
                                             <align>left</align>
@@ -335,7 +335,7 @@
                                         <control type="label">
                                             <posx>0</posx>
                                             <posy>50</posy>
-                                            <width>692</width>
+                                            <width>652</width>
                                             <height>30</height>
                                             <font>font10</font>
                                             <align>left</align>
@@ -441,19 +441,19 @@
                                 </control>
                                 <control type="label">
                                     <visible>String.IsEmpty(ListItem.Property(track.ID)) | !StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                    <posx>48</posx>
+                                    <posx>22</posx>
                                     <posy>0</posy>
-                                    <width>50</width>
+                                    <width>60</width>
                                     <height>100</height>
                                     <font>font12</font>
-                                    <align>left</align>
+                                    <align>center</align>
                                     <aligny>center</aligny>
                                     <textcolor>B8000000</textcolor>
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                                 </control>
                                 <control type="image">
                                     <visible>!String.IsEmpty(ListItem.Property(track.ID)) + StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                    <posx>48</posx>
+                                    <posx>36</posx>
                                     <posy>32.5</posy>
                                     <width>35</width>
                                     <height>35</height>
@@ -472,12 +472,12 @@
                                         <aspectratio>scale</aspectratio>
                                     </control>
                                     <control type="group">
-                                        <posx>235</posx>
+                                        <posx>255</posx>
                                         <posy>0</posy>
                                         <control type="label">
                                             <posx>0</posx>
                                             <posy>16</posy>
-                                            <width>638</width>
+                                            <width>618</width>
                                             <height>30</height>
                                             <font>font12</font>
                                             <align>left</align>
@@ -488,7 +488,7 @@
                                         <control type="label">
                                             <posx>0</posx>
                                             <posy>51</posy>
-                                            <width>638</width>
+                                            <width>618</width>
                                             <height>30</height>
                                             <font>font10</font>
                                             <align>left</align>


### PR DESCRIPTION
GHI (If applicable): #

## Description:
With track numbers with 4 or more digits, only the first digit is displayed and the rest is replaced with dots.

## Checklist:
- [x] I have based this PR against the develop branch
