### PR TITLE
Playlists visuals

### DIFF
--- a/resources/skins/Main/1080i/script-plex-album.xml
+++ b/resources/skins/Main/1080i/script-plex-album.xml
@@ -157,19 +157,19 @@
                             <posy>24</posy>
                             <control type="label">
                                 <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                <posx>0</posx>
+                                <posx>-10</posx>
                                 <posy>0</posy>
-                                <width>50</width>
+                                <width>60</width>
                                 <height>76</height>
                                 <font>font10</font>
-                                <align>left</align>
+                                <align>center</align>
                                 <aligny>center</aligny>
                                 <textcolor>D8FFFFFF</textcolor>
                                 <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                             </control>
                             <control type="image">
                                 <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                <posx>0</posx>
+                                <posx>2</posx>
                                 <posy>21</posy>
                                 <width>35</width>
                                 <height>35</height>
@@ -238,19 +238,19 @@
                                 <posy>24</posy>
                                 <control type="label">
                                     <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                    <posx>0</posx>
+                                    <posx>-10</posx>
                                     <posy>0</posy>
-                                    <width>50</width>
+                                    <width>60</width>
                                     <height>76</height>
                                     <font>font10</font>
-                                    <align>left</align>
+                                    <align>center</align>
                                     <aligny>center</aligny>
                                     <textcolor>D8FFFFFF</textcolor>
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                                 </control>
                                 <control type="image">
                                     <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                    <posx>0</posx>
+                                    <posx>2</posx>
                                     <posy>21</posy>
                                     <width>35</width>
                                     <height>35</height>
@@ -327,7 +327,7 @@
                                 </control>
                                 <control type="image">
                                     <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                    <posx>48</posx>
+                                    <posx>36</posx>
                                     <posy>21</posy>
                                     <width>35</width>
                                     <height>35</height>

--- a/resources/skins/Main/1080i/script-plex-music_current_playlist.xml
+++ b/resources/skins/Main/1080i/script-plex-music_current_playlist.xml
@@ -149,19 +149,19 @@
                             <posy>24</posy>
                             <control type="label">
                                 <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                <posx>0</posx>
+                                <posx>-10</posx>
                                 <posy>0</posy>
-                                <width>50</width>
+                                <width>60</width>
                                 <height>100</height>
                                 <font>font10</font>
-                                <align>left</align>
+                                <align>center</align>
                                 <aligny>center</aligny>
                                 <textcolor>D8FFFFFF</textcolor>
                                 <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                             </control>
                             <control type="image">
                                 <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                <posx>0</posx>
+                                <posx>2</posx>
                                 <posy>32.5</posy>
                                 <width>35</width>
                                 <height>35</height>
@@ -234,12 +234,12 @@
                                 <posy>24</posy>
                                 <control type="label">
                                     <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                    <posx>0</posx>
+                                    <posx>-10</posx>
                                     <posy>0</posy>
-                                    <width>50</width>
+                                    <width>60</width>
                                     <height>100</height>
                                     <font>font10</font>
-                                    <align>left</align>
+                                    <align>center</align>
                                     <aligny>center</aligny>
                                     <textcolor>D8FFFFFF</textcolor>
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
@@ -330,19 +330,19 @@
                                 </control>
                                 <control type="label">
                                     <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                    <posx>48</posx>
+                                    <posx>24</posx>
                                     <posy>0</posy>
-                                    <width>50</width>
+                                    <width>60</width>
                                     <height>100</height>
                                     <font>font12</font>
-                                    <align>left</align>
+                                    <align>center</align>
                                     <aligny>center</aligny>
                                     <textcolor>B8000000</textcolor>
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                                 </control>
                                 <control type="image">
                                     <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                    <posx>48</posx>
+                                    <posx>36</posx>
                                     <posy>32.5</posy>
                                     <width>35</width>
                                     <height>35</height>

--- a/resources/skins/Main/1080i/script-plex-music_current_playlist.xml
+++ b/resources/skins/Main/1080i/script-plex-music_current_playlist.xml
@@ -288,7 +288,7 @@
                                     </control>
                                 </control>
                                 <control type="label">
-                                    <posx>661</posx>
+                                    <posx>669</posx>
                                     <posy>0</posy>
                                     <width>200</width>
                                     <height>100</height>
@@ -384,7 +384,7 @@
                                     </control>
                                 </control>
                                 <control type="label">
-                                    <posx>727</posx>
+                                    <posx>735</posx>
                                     <posy>0</posy>
                                     <width>200</width>
                                     <height>100</height>

--- a/resources/skins/Main/1080i/script-plex-playlist.xml
+++ b/resources/skins/Main/1080i/script-plex-playlist.xml
@@ -156,12 +156,12 @@
                             <posy>24</posy>
                             <control type="label">
                                 <visible>String.IsEmpty(ListItem.Property(track.ID)) | !StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                <posx>0</posx>
+                                <posx>-10</posx>
                                 <posy>0</posy>
-                                <width>50</width>
+                                <width>60</width>
                                 <height>100</height>
                                 <font>font10</font>
-                                <align>left</align>
+                                <align>center</align>
                                 <aligny>center</aligny>
                                 <textcolor>D8FFFFFF</textcolor>
                                 <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
@@ -289,12 +289,12 @@
                                 <posy>24</posy>
                                 <control type="label">
                                     <visible>String.IsEmpty(ListItem.Property(track.ID)) | !StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                    <posx>0</posx>
+                                    <posx>-10</posx>
                                     <posy>0</posy>
-                                    <width>50</width>
+                                    <width>60</width>
                                     <height>100</height>
                                     <font>font10</font>
-                                    <align>left</align>
+                                    <align>center</align>
                                     <aligny>center</aligny>
                                     <textcolor>D8FFFFFF</textcolor>
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
@@ -426,6 +426,15 @@
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
+                                    <width>1044</width>
+                                    <height>100</height>
+                                    <texture border="12">script.plex/white-square-rounded.png</texture>
+                                    <colordiffuse>FFE5A00D</colordiffuse>
+                                </control>
+                                <!-- comment the previous and uncomment the following for re-enabling options button -->
+                                <!--<control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
                                     <width>999</width>
                                     <height>100</height>
                                     <texture border="12">script.plex/white-square-left-rounded.png</texture>
@@ -438,22 +447,22 @@
                                     <height>100</height>
                                     <texture>script.plex/buttons/more-vertical.png</texture>
                                     <colordiffuse>99FFFFFF</colordiffuse>
-                                </control>
+                                </control>-->
                                 <control type="label">
                                     <visible>String.IsEmpty(ListItem.Property(track.ID)) | !StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                    <posx>48</posx>
+                                    <posx>24</posx>
                                     <posy>0</posy>
-                                    <width>50</width>
+                                    <width>60</width>
                                     <height>100</height>
                                     <font>font12</font>
-                                    <align>left</align>
+                                    <align>center</align>
                                     <aligny>center</aligny>
                                     <textcolor>B8000000</textcolor>
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                                 </control>
                                 <control type="image">
                                     <visible>!String.IsEmpty(ListItem.Property(track.ID)) + StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                    <posx>48</posx>
+                                    <posx>36</posx>
                                     <posy>32.5</posy>
                                     <width>35</width>
                                     <height>35</height>
@@ -544,7 +553,7 @@
                                     </control>
                                 </control>
                                 <control type="label">
-                                    <posx>776</posx>
+                                    <posx>798</posx>
                                     <posy>0</posy>
                                     <width>200</width>
                                     <height>100</height>

--- a/resources/skins/Main/1080i/script-plex-playlist.xml
+++ b/resources/skins/Main/1080i/script-plex-playlist.xml
@@ -168,7 +168,7 @@
                             </control>
                             <control type="image">
                                 <visible>!String.IsEmpty(ListItem.Property(track.ID)) + StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
-                                <posx>0</posx>
+                                <posx>2</posx>
                                 <posy>32.5</posy>
                                 <width>35</width>
                                 <height>35</height>
@@ -553,7 +553,7 @@
                                     </control>
                                 </control>
                                 <control type="label">
-                                    <posx>798</posx>
+                                    <posx>802</posx>
                                     <posy>0</posy>
                                     <width>200</width>
                                     <height>100</height>

--- a/resources/skins/Main/1080i/script-plex-video_current_playlist.xml
+++ b/resources/skins/Main/1080i/script-plex-video_current_playlist.xml
@@ -43,19 +43,19 @@
                             <posy>24</posy>
                             <control type="label">
                                 <visible>String.IsEmpty(ListItem.Property(playing))</visible>
-                                <posx>0</posx>
+                                <posx>-10</posx>
                                 <posy>0</posy>
-                                <width>50</width>
+                                <width>60</width>
                                 <height>100</height>
                                 <font>font10</font>
-                                <align>left</align>
+                                <align>center</align>
                                 <aligny>center</aligny>
                                 <textcolor>D8FFFFFF</textcolor>
                                 <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                             </control>
                             <control type="image">
                                 <visible>!String.IsEmpty(ListItem.Property(playing))</visible>
-                                <posx>0</posx>
+                                <posx>2</posx>
                                 <posy>32.5</posy>
                                 <width>35</width>
                                 <height>35</height>
@@ -176,12 +176,12 @@
                                 <posy>24</posy>
                                 <control type="label">
                                     <visible>String.IsEmpty(ListItem.Property(playing))</visible>
-                                    <posx>0</posx>
+                                    <posx>-10</posx>
                                     <posy>0</posy>
-                                    <width>50</width>
+                                    <width>60</width>
                                     <height>100</height>
                                     <font>font10</font>
-                                    <align>left</align>
+                                    <align>center</align>
                                     <aligny>center</aligny>
                                     <textcolor>D8FFFFFF</textcolor>
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
@@ -278,7 +278,7 @@
                                     </control>
                                 </control>
                                 <control type="label">
-                                    <posx>730</posx>
+                                    <posx>756</posx>
                                     <posy>0</posy>
                                     <width>200</width>
                                     <height>100</height>
@@ -313,6 +313,15 @@
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
+                                    <width>1044</width>
+                                    <height>100</height>
+                                    <texture border="12">script.plex/white-square-rounded.png</texture>
+                                    <colordiffuse>FFE5A00D</colordiffuse>
+                                </control>
+                                <!-- comment the previous and uncomment the following for re-enabling options button -->
+                                <!--<control type="image">
+                                    <posx>0</posx>
+                                    <posy>0</posy>
                                     <width>999</width>
                                     <height>100</height>
                                     <texture border="12">script.plex/white-square-left-rounded.png</texture>
@@ -325,22 +334,22 @@
                                     <height>100</height>
                                     <texture>script.plex/buttons/more-vertical.png</texture>
                                     <colordiffuse>99FFFFFF</colordiffuse>
-                                </control>
+                                </control>-->
                                 <control type="label">
                                     <visible>String.IsEmpty(ListItem.Property(playing))</visible>
-                                    <posx>48</posx>
+                                    <posx>24</posx>
                                     <posy>0</posy>
-                                    <width>50</width>
+                                    <width>60</width>
                                     <height>100</height>
                                     <font>font12</font>
-                                    <align>left</align>
+                                    <align>center</align>
                                     <aligny>center</aligny>
                                     <textcolor>B8000000</textcolor>
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                                 </control>
                                 <control type="image">
                                     <visible>!String.IsEmpty(ListItem.Property(playing))</visible>
-                                    <posx>48</posx>
+                                    <posx>36</posx>
                                     <posy>32.5</posy>
                                     <width>35</width>
                                     <height>35</height>
@@ -431,7 +440,7 @@
                                     </control>
                                 </control>
                                 <control type="label">
-                                    <posx>776</posx>
+                                    <posx>802</posx>
                                     <posy>0</posy>
                                     <width>200</width>
                                     <height>100</height>


### PR DESCRIPTION
GHI (If applicable): #

## Description:
- fixes big playlists by visually supporting track numbers > 999
- correctly follows the zoom factor when a playlist item is highlighted
- reversibly removes the currently unused options button of playlist items

## Checklist:
- [x] I have based this PR against the develop branch
