### PR TITLE
Fix manual quality selection; remove super-low video qualities

### DIFF
--- a/lib/_included_packages/plexnet/plexapp.py
+++ b/lib/_included_packages/plexnet/plexapp.py
@@ -295,6 +295,16 @@ class PlayerSettingsInterface(object):
         else:
             return 360
 
+    def getMaxBitrate(self, qualityType):
+        qualityIndex = self.getQualityIndex(qualityType)
+
+        qualities = self.getGlobal("qualities", [])
+        for quality in qualities:
+            if quality.index == qualityIndex:
+                return util.validInt(quality.maxBitrate)
+
+        return 0
+
 
 class DumbInterface(AppInterface):
     _prefs = {}

--- a/lib/windows/playersettings.py
+++ b/lib/windows/playersettings.py
@@ -252,7 +252,8 @@ def showSubtitlesDialog(video, non_playback=False):
 
 
 def showQualityDialog(video, non_playback=False, selected_idx=None):
-    options = [(13 - i, T(l)) for (i, l) in enumerate((32001, 32002, 32003, 32004, 32005, 32006, 32007, 32008, 32009, 32010, 32011, 32012, 32013, 32014))]
+    options = [(13 - i, T(l)) for (i, l) in enumerate((32001, 32002, 32003, 32004, 32005, 32006, 32007, 32008, 32009,
+                                                       32010, 32011))]
 
     choice = showOptionsDialog('Quality', options, non_playback=non_playback, selected_idx=selected_idx)
     if choice is None:

--- a/lib/windows/settings.py
+++ b/lib/windows/settings.py
@@ -535,7 +535,8 @@ def showSubtitlesDialog(video):
 
 
 def showQualityDialog(video):
-    options = [(13 - i, T(l)) for (i, l) in enumerate((32001, 32002, 32003, 32004, 32005, 32006, 32007, 32008, 32009, 32010, 32011, 32012, 32013, 32014))]
+    options = [(13 - i, T(l)) for (i, l) in enumerate((32001, 32002, 32003, 32004, 32005, 32006, 32007, 32008, 32009,
+                                                       32010, 32011))]
 
     choice = showOptionsDialog(T(32397, 'Quality'), options)
     if choice is None:


### PR DESCRIPTION
GHI (If applicable): #

## Description:
- fix: manual quality selection is broken right now - only differing resolutions lead to transcoding, as `getMaxBitrate` isn't implemented by the correct interface
- remove super-low unnecessary "video bitrates": 64, 96, 208 kbps

## Checklist:
- [x] I have based this PR against the develop branch
