### PR TITLE
Improved photo playback/slideshow

### DIFF
--- a/lib/_included_packages/plexnet/playqueue.py
+++ b/lib/_included_packages/plexnet/playqueue.py
@@ -481,11 +481,37 @@ class PlayQueue(signalsmixin.SignalsMixin):
         return self.items().index(self.current()) > 0
 
     def next(self):
-        if not self.hasNext():
-            return None
-
         if self.isRepeatOne:
             return self.current()
+
+        item = self.getNext()
+        if not item:
+            return None
+
+        self.selectedId = item.playQueueItemID.asInt()
+        return item
+
+    def prev(self):
+        if self.isRepeatOne:
+            return self.current()
+
+        item = self.getPrev()
+        if not item:
+            return None
+
+        self.selectedId = item.playQueueItemID.asInt()
+        return item
+
+    def getPrev(self):
+        if not self.hasPrev():
+            return None
+
+        pos = self.items().index(self.current()) - 1
+        return self.items()[pos]
+
+    def getNext(self):
+        if not self.hasNext():
+            return None
 
         pos = self.items().index(self.current()) + 1
         if pos >= len(self.items()):
@@ -493,19 +519,8 @@ class PlayQueue(signalsmixin.SignalsMixin):
                 return None
             pos = 0
 
-        item = self.items()[pos]
-        self.selectedId = item.playQueueItemID.asInt()
-        return item
+        return self.items()[pos]
 
-    def prev(self):
-        if not self.hasPrev():
-            return None
-        if self.isRepeatOne:
-            return self.current()
-        pos = self.items().index(self.current()) - 1
-        item = self.items()[pos]
-        self.selectedId = item.playQueueItemID.asInt()
-        return item
 
     def setCurrent(self, pos):
         if pos < 0 or pos >= len(self.items()):

--- a/lib/_included_packages/plexnet/plexplayer.py
+++ b/lib/_included_packages/plexnet/plexplayer.py
@@ -608,7 +608,6 @@ class PlexPhotoPlayer(object):
             path = part.key or part.thumb
             server = item.getServer()
 
-            obj.path = path
             obj.url = server.buildUrl(path, True)
             obj.enableBlur = server.supportsPhotoTranscoding
 

--- a/lib/_included_packages/plexnet/plexplayer.py
+++ b/lib/_included_packages/plexnet/plexplayer.py
@@ -598,14 +598,17 @@ class PlexPhotoPlayer(object):
         self.media = item.media()[0]
         self.metadata = None
 
-    def build(self):
-        if self.media.parts and self.media.parts[0]:
+    def build(self, item=None):
+        item = item or self.item
+        media = item.media()[0]
+        if media.parts and media.parts[0]:
             obj = util.AttributeDict()
 
-            part = self.media.parts[0]
+            part = media.parts[0]
             path = part.key or part.thumb
-            server = self.item.getServer()
+            server = item.getServer()
 
+            obj.path = path
             obj.url = server.buildUrl(path, True)
             obj.enableBlur = server.supportsPhotoTranscoding
 

--- a/lib/windows/photos.py
+++ b/lib/windows/photos.py
@@ -231,7 +231,7 @@ class PhotoWindow(kodigui.BaseWindow):
 
     def updatePqueueListSelection(self, current=None):
         selected = self.pqueueList.getListItemByDataSource(current or self.playQueue.current())
-        if not selected:
+        if not selected or not selected.pos():
             return
 
         self.pqueueList.selectItem(selected.pos())

--- a/lib/windows/photos.py
+++ b/lib/windows/photos.py
@@ -422,12 +422,12 @@ class PhotoWindow(kodigui.BaseWindow):
     def prev(self):
         if not self.playQueue.getPrev():
             return
-        self.showPhoto(trigger=lambda: self.playQueue.next())
+        self.showPhoto(trigger=lambda: self.playQueue.prev())
 
     def next(self):
         if not self.playQueue.getNext():
             return
-        self.showPhoto(trigger=lambda: self.playQueue.prev())
+        self.showPhoto(trigger=lambda: self.playQueue.next())
 
     def play(self):
         self.setProperty('playing', '1')

--- a/lib/windows/photos.py
+++ b/lib/windows/photos.py
@@ -297,7 +297,7 @@ class PhotoWindow(kodigui.BaseWindow):
                 if isCurrent and not self.initialLoad:
                     self.setBoolProperty('is.updating', True)
 
-                path, background = self.getCachedPhotoData(meta.path, url, bgURL)
+                path, background = self.getCachedPhotoData(url, bgURL)
                 if not (path and background):
                     return
 
@@ -327,14 +327,13 @@ class PhotoWindow(kodigui.BaseWindow):
         finally:
             self.setBoolProperty('is.updating', False)
 
-    def getCachedPhotoData(self, path, url, bgURL):
+    def getCachedPhotoData(self, url, bgURL):
         if not url:
             return
 
-        ext = os.path.splitext(path)[1]
         basename = hashlib.sha1(url).hexdigest()
-        tmpPath = os.path.join(self.tempFolder, basename + ext)
-        tmpBgPath = os.path.join(self.tempFolder, "%s_bg%s" % (basename, ext))
+        tmpPath = os.path.join(self.tempFolder, basename)
+        tmpBgPath = os.path.join(self.tempFolder, "%s_bg" % basename)
 
         for p, url in ((tmpPath, url), (tmpBgPath, bgURL)):
             if not os.path.exists(p):# and not xbmc.getCacheThumbName(tmpFn):

--- a/lib/windows/photos.py
+++ b/lib/windows/photos.py
@@ -293,7 +293,7 @@ class PhotoWindow(kodigui.BaseWindow):
                     self.setBoolProperty('is.updating', True)
 
                 path, background = self.getCachedPhotoData(meta.path, url, bgURL)
-                if not path and background:
+                if not (path and background):
                     return
 
                 if (path, background) not in self.photoStack:

--- a/lib/windows/photos.py
+++ b/lib/windows/photos.py
@@ -260,6 +260,10 @@ class PhotoWindow(kodigui.BaseWindow):
             while waitedFor < 10:
                 if not self.showPhotoThread.isAlive() and not xbmc.abortRequested:
                     return self.showPhoto(**kwargs)
+                elif xbmc.abortRequested:
+                    self.setBoolProperty('is.updating', False)
+                    return
+
                 util.MONITOR.waitForAbort(0.1)
                 waitedFor += 0.1
 

--- a/lib/windows/photos.py
+++ b/lib/windows/photos.py
@@ -271,7 +271,8 @@ class PhotoWindow(kodigui.BaseWindow):
         :return:
         """
         photo = self.playQueue.current()
-        loadItems = (photo, self.playQueue.getNext(), self.playQueue.getPrev())
+        next = self.playQueue.getNext()
+        loadItems = (photo, next, self.playQueue.getPrev())
         for item in loadItems:
             item.softReload()
 
@@ -297,7 +298,11 @@ class PhotoWindow(kodigui.BaseWindow):
                     return
 
                 if (path, background) not in self.photoStack:
-                    addToStack.append((path, background))
+                    if item == next:
+                        # move the next image to the top of the stack
+                        addToStack.insert(0, (path, background))
+                    else:
+                        addToStack.append((path, background))
 
                 if isCurrent:
                     self._reallyShowPhoto(item, path, background)

--- a/lib/windows/photos.py
+++ b/lib/windows/photos.py
@@ -254,7 +254,7 @@ class PhotoWindow(kodigui.BaseWindow):
             self.showPhotoThread.start()
 
         # wait for the current thread to end, which might still be loading the surrounding images, for 10 seconds
-        elif self.showPhotoThread and self.showPhotoThread.isAlive():
+        elif self.showPhotoThread.isAlive():
             waitedFor = 0
             self.setBoolProperty('is.updating', True)
             while waitedFor < 10:

--- a/resources/skins/Main/1080i/script-plex-photo.xml
+++ b/resources/skins/Main/1080i/script-plex-photo.xml
@@ -37,9 +37,28 @@
                 <posy>0</posy>
                 <width>1920</width>
                 <height>1080</height>
-                <fadetime>200</fadetime>
+                <fadetime>1000</fadetime>
                 <texture fallback="script.plex/thumb_fallbacks/broken-photo.png" background="true">$INFO[Window.Property(photo)]</texture>
                 <aspectratio>keep</aspectratio>
+            </control>
+            <control type="group">
+                <visible>!String.IsEmpty(Window.Property(is.updating))</visible>
+                <animation effect="fade" time="500">VisibleChange</animation>
+                <control type="image">
+                    <posx>840</posx>
+                    <posy>465</posy>
+                    <width>240</width>
+                    <height>150</height>
+                    <texture>script.plex/busy-back.png</texture>
+                    <colordiffuse>A0FFFFFF</colordiffuse>
+                </control>
+                <control type="image">
+                    <posx>915</posx>
+                    <posy>521</posy>
+                    <width>90</width>
+                    <height>38</height>
+                    <texture diffuse="script.plex/busy-diffuse.png">script.plex/busy.gif</texture>
+                </control>
             </control>
         </control>
         <control type="togglebutton" id="250">


### PR DESCRIPTION
GHI (If applicable): #

## Description:
Fast pre-loading photo slideshow

- preloads the current, previous and next items using temporary files
- takes care of temp file cleanup (holds temporary instances of a maximum of 10 photos and their backgrounds)
- shows a transition between on changes
- tries to not show any loading indicators if possible
- smoothly handles action spam (multiple `next` requests in quick succession for example)

## Checklist:
- [x] I have based this PR against the develop branch
