### PR TITLE
Kodi PVR Button

### DIFF
--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -203,6 +203,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
 
     SEARCH_BUTTON_ID = 203
     SERVER_LIST_ID = 260
+    PVR_BUTTON_ID = 6969
 
     PLAYER_STATUS_BUTTON_ID = 204
 
@@ -402,6 +403,9 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
             if controlID == self.SECTION_LIST_ID:
                 self.checkSectionItem(action=action)
 
+            if controlID == self.PVR_BUTTON_ID and action == xbmcgui.ACTION_MOUSE_LEFT_CLICK:
+                self.pvrButtonClicked()
+
             if controlID == self.SERVER_BUTTON_ID:
                 if action == xbmcgui.ACTION_SELECT_ITEM:
                     self.showServers()
@@ -424,6 +428,24 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
             elif controlID == self.USER_BUTTON_ID and action == xbmcgui.ACTION_MOVE_LEFT:
                 self.setFocusId(self.SERVER_BUTTON_ID)
             elif controlID == self.SEARCH_BUTTON_ID and action == xbmcgui.ACTION_MOVE_RIGHT:
+                if xbmc.getCondVisibility('System.HasPVRAddon'):
+                    self.setFocusId(self.PVR_BUTTON_ID)
+                else:
+                    if xbmc.getCondVisibility('Player.HasMedia + Control.IsVisible({0})'.format(self.PLAYER_STATUS_BUTTON_ID)):
+                        self.setFocusId(self.PLAYER_STATUS_BUTTON_ID)
+                    else:
+                        self.setFocusId(self.SERVER_BUTTON_ID)
+            elif controlID == self.PLAYER_STATUS_BUTTON_ID and action == xbmcgui.ACTION_MOVE_LEFT:
+                if xbmc.getCondVisibility('System.HasPVRAddon'):
+                    self.setFocusId(self.PVR_BUTTON_ID)
+                else:
+                    self.setFocusId(self.SEARCH_BUTTON_ID)
+            elif controlID == self.SERVER_BUTTON_ID and action == xbmcgui.ACTION_MOVE_LEFT:
+                if xbmc.getCondVisibility('Player.HasMedia + Control.IsVisible({0})'.format(self.PLAYER_STATUS_BUTTON_ID)):
+                    self.setFocusId(self.PLAYER_STATUS_BUTTON_ID)
+                else:
+                    self.setFocusId(self.PVR_BUTTON_ID)
+            elif controlID == self.PVR_BUTTON_ID and action == xbmcgui.ACTION_MOVE_RIGHT:
                 if xbmc.getCondVisibility('Player.HasMedia + Control.IsVisible({0})'.format(self.PLAYER_STATUS_BUTTON_ID)):
                     self.setFocusId(self.PLAYER_STATUS_BUTTON_ID)
                 else:
@@ -450,7 +472,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
 
                     if util.advancedSettings.fastBack and not optionsFocused and offSections \
                             and self.lastFocusID not in (self.USER_BUTTON_ID, self.SERVER_BUTTON_ID,
-                                                         self.SEARCH_BUTTON_ID, self.SECTION_LIST_ID):
+                                                         self.SEARCH_BUTTON_ID, self.SECTION_LIST_ID, self.PVR_BUTTON_ID):
                         self.setProperty('hub.focus', '0')
                         self.setFocusId(self.SECTION_LIST_ID)
                         return
@@ -479,6 +501,8 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
             self.sectionClicked()
         # elif controlID == self.SERVER_BUTTON_ID:
         #     self.showServers()
+        elif controlID == self.PVR_BUTTON_ID:
+            self.pvrButtonClicked()
         elif controlID == self.SERVER_LIST_ID:
             self.setBoolProperty('show.servers', False)
             self.selectServer()
@@ -494,6 +518,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
             self.hubItemClicked(controlID)
         elif controlID == self.SEARCH_BUTTON_ID:
             self.searchButtonClicked()
+
 
     def onFocus(self, controlID):
         self.lastFocusID = controlID
@@ -521,6 +546,9 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
 
     def searchButtonClicked(self):
         self.processCommand(search.dialog(self))
+
+    def pvrButtonClicked(self):
+        xbmc.executebuiltin("ActivateWindow(10702)")
 
     def updateOnDeckHubs(self, **kwargs):
         tasks = [UpdateHubTask().setup(hub, self.updateHubCallback) for hub in self.updateHubs.values()]

--- a/resources/skins/Main/1080i/script-plex-home.xml
+++ b/resources/skins/Main/1080i/script-plex-home.xml
@@ -7804,13 +7804,32 @@
                 <control type="label">
                     <posx>160</posx>
                     <posy>35</posy>
-                    <width>500</width>
+                    <width>200</width>
                     <height>65</height>
                     <font>font12</font>
                     <align>left</align>
                     <aligny>center</aligny>
                     <textcolor>FFFFFFFF</textcolor>
                     <label>[UPPERCASE]$ADDON[script.plex 32430][/UPPERCASE]</label>
+                </control>
+                <control type="button" id="6969">
+			        <visible>[System.HasPVRAddon]</visible>
+                    <posx>600</posx>
+                    <posy>35</posy>
+                    <width>200</width>
+                    <height>66</height>
+                    <font>font12</font>
+                    <onleft>203</onleft>
+                    <ondown>50</ondown>
+                    <textcolor>FFFFFFFF</textcolor>
+                    <focusedcolor>FF000000</focusedcolor>
+                    <align>right</align>
+                    <aligny>center</aligny>
+                    <texturefocus colordiffuse="FFE5A00D" border="10">script.plex/white-square-rounded.png</texturefocus>
+                    <texturenofocus>-</texturenofocus>
+                    <textoffsetx>0</textoffsetx>
+                    <textoffsety>0</textoffsety>
+                    <label>Kodi PVR</label>
                 </control>
             </control>
             <control type="group">
@@ -7823,7 +7842,7 @@
                     <posy>38</posy>
                     <width>260</width>
                     <height>75</height>
-                    <onleft>203</onleft>
+                    <onleft>6969</onleft>
                     <ondown>50</ondown>
                     <font>font12</font>
                     <textcolor>FFFFFFFF</textcolor>
@@ -8023,7 +8042,7 @@
                                 <height>900</height>
                                 <onup>201</onup>
                                 <ondown>noop</ondown>
-                                <onleft>203</onleft>
+                                <onleft>6969</onleft>
                                 <onright>202</onright>
                                 <onunfocus>SetProperty(show.servers,)</onunfocus>
                                 <scrolltime>200</scrolltime>


### PR DESCRIPTION
Addition of a button to the top of the Home page to launch the Kodi PVR Manager in the TV Guide View.

## Description:
Uses the base Kodi TV Guide Skin however
Only displayed if the Kodi PVR is available.
All setup is done through Kodi, this just saves the user having to leave Plex-For-Kodi in order to view Live TV.

ID of 6969 was picked to not clash with anything already planned, expect that this would be changed if implemented.

## Checklist:
- [ ] I have based this PR against the develop branch
