### PR TITLE
Non-intrusively fix resume behaviour on DSPlayer

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -287,15 +287,19 @@ class SeekPlayerHandler(BasePlayerHandler):
             self.seek(max(self.trueTime - 30, 0) * 1000, seeking=self.SEEK_REWIND)
 
     def seekAbsolute(self, seek=None):
-        self.seekOnStart = seek or self.seekOnStart
+        self.seekOnStart = seek or (self.seekOnStart if self.seekOnStart else None)
         if self.seekOnStart is not None:
             seekSeconds = self.seekOnStart / 1000.0
             try:
                 if seekSeconds >= self.player.getTotalTime():
+                    util.DEBUG_LOG("SeekAbsolute: Bad offset: {0}".format(seekSeconds))
                     return False
             except RuntimeError:  # Not playing a file
+                util.DEBUG_LOG("SeekAbsolute: runtime error")
                 return False
             self.updateNowPlaying(state=self.player.STATE_PAUSED)  # To for update after seek
+
+            util.DEBUG_LOG("SeekAbsolute: Seeking to {0}".format(self.seekOnStart))
             self.player.seekTime(self.seekOnStart / 1000.0)
         return True
 
@@ -353,9 +357,13 @@ class SeekPlayerHandler(BasePlayerHandler):
 
     def onPlayBackSeek(self, stime, offset):
         if self.seekOnStart:
+            seeked = False
             if self.dialog:
-                self.dialog.tick(stime)
-            self.seekOnStart = 0
+                seeked = self.dialog.tick(stime)
+
+            if seeked:
+                util.DEBUG_LOG("OnPlayBackSeek: Seeked on start")
+                self.seekOnStart = 0
             return
 
         self.updateOffset()
@@ -921,7 +929,7 @@ class PlexPlayer(xbmc.Player, signalsmixin.SignalsMixin):
         self.handler.onPlayBackEnded()
 
     def onPlayBackSeek(self, time, offset):
-        util.DEBUG_LOG('Player - SEEK')
+        util.DEBUG_LOG('Player - SEEK: %i' % offset)
         if not self.handler:
             return
         self.handler.onPlayBackSeek(time, offset)

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -859,10 +859,11 @@ class SeekDialog(kodigui.BaseDialog):
             self.resetSeeking()
             return
 
-        if self.autoSeekTimeout and time.time() >= self.autoSeekTimeout and self.offset != self.selectedOffset:
+        if offset or (self.autoSeekTimeout and time.time() >= self.autoSeekTimeout and
+                      self.offset != self.selectedOffset):
             self.resetAutoSeekTimer(None)
             self.doSeek()
-            return
+            return True
 
         self.updateCurrent(update_position_control=not self._seeking and not self._applyingSeek)
 


### PR DESCRIPTION


GHI (If applicable): #189

## Description:
This fixes a situation unique to DSPlayer, where the seekOnStart happens with a value of zero almost immediately. The fix is non-intrusive and doesn't change the behaviour for the default video player.

It keeps track of whether a seekOnStart has actually happened (was greater than 0) and keeps the seekOnStart value until it has been applied.

## Checklist:
- [x] I have based this PR against the develop branch
