### PR TITLE
Fix dangling references

### DIFF
--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -561,6 +561,9 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
 
         self.updateListItem(mli)
 
+        if not mli:
+            return
+
         if not mli.dataSource.exists():
             control.removeItem(mli.pos())
 

--- a/lib/windows/kodigui.py
+++ b/lib/windows/kodigui.py
@@ -223,6 +223,14 @@ class ControlledDialog(ControlledBase, BaseDialog):
 DUMMY_LIST_ITEM = xbmcgui.ListItem()
 
 
+class DummyDataSource(object):
+    def exists(self):
+        return False
+
+
+DUMMY_DATA_SOURCE = DummyDataSource()
+
+
 class ManagedListItem(object):
     def __init__(self, label='', label2='', iconImage='', thumbnailImage='', path='', data_source=None, properties=None):
         self._listItem = xbmcgui.ListItem(label, label2, iconImage, thumbnailImage, path)
@@ -259,6 +267,7 @@ class ManagedListItem(object):
     def invalidate(self):
         self._valid = False
         self._listItem = DUMMY_LIST_ITEM
+        self.dataSource = DUMMY_DATA_SOURCE
 
     def _takeListItem(self, manager, lid):
         self._manager = manager

--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -1184,6 +1184,9 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
         elif self.section.TYPE in ('photo', 'photodirectory'):
             self.showPhoto(mli.dataSource)
 
+        if not mli:
+            return
+
         if not mli.dataSource.exists():
             self.showPanelControl.removeItem(mli.pos())
             return

--- a/lib/windows/subitems.py
+++ b/lib/windows/subitems.py
@@ -331,6 +331,9 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         elif self.mediaItem.type == 'artist':
             w = tracks.AlbumWindow.open(album=mli.dataSource, parent_list=self.subItemListControl)
 
+        if not mli:
+            return
+
         if not mli.dataSource.exists():
             self.subItemListControl.removeItem(mli.pos())
 


### PR DESCRIPTION
GHI (If applicable): #

## Description:
This takes care of leftover references upon plugin shutdown by setting ManagedListItem's dataSource to a dummy instance.

## Checklist:
- [x] I have based this PR against the develop branch
