### PR TITLE
Fix progress percentage display with progress < 2%

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -545,6 +545,7 @@ def getProgressImage(obj):
         return ''
     pct = int((obj.viewOffset.asInt() / obj.duration.asFloat()) * 100)
     pct = pct - pct % 2  # Round to even number - we have even numbered progress only
+    pct = max(pct, 2)
     return 'script.plex/progress/{0}.png'.format(pct)
 
 


### PR DESCRIPTION
GHI (If applicable): #

## Description:
Clamps the lower boundary of the progress indicator to 2% to fix "no progress" display issues for items with less than 2% progress.

## Checklist:
- [x] I have based this PR against the develop branch
