### PR TITLE
Fixed info display

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -1018,7 +1018,7 @@ class PlexPlayer(xbmc.Player, signalsmixin.SignalsMixin):
         while self.isPlayingVideo() and not xbmc.abortRequested and not self._closed:
             self.currentTime = self.getTime()
             util.MONITOR.waitForAbort(0.1)
-            if xbmc.getCondVisibility('Window.IsActive(videoosd) | Player.ShowInfo'):
+            if xbmc.getCondVisibility('Window.IsActive(videoosd)'):
                 if not self.hasOSD:
                     self.hasOSD = True
                     self.onVideoOSD()


### PR DESCRIPTION
GHI (If applicable): None

## Description:
The player info display shows and then immediately hides.  This makes it stay up, at least on V18 Leia.  I do not know how this behaves on prior versions of Kodi.

## Checklist:
- [X] I have based this PR against the develop branch
