### PR TITLE
Allow seeking with varying delay.

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -87,6 +87,7 @@ class AdvancedSettings(object):
         ("debug", False),
         ("kodi_skip_stepping", False),
         ("auto_seek", True),
+        ("auto_seek_delay", 0),
         ("dynamic_timeline_seek", False),
         ("fast_back", False),
     )

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -975,6 +975,10 @@ msgctxt "#32485"
 msgid "Go back instantly with the previous menu action in scrolled views"
 msgstr ""
 
+msgctxt "#32487"
+msgid "Seek Delay"
+msgstr ""
+
 msgctxt "#32492"
 msgid "Kodi Subtitle Settings"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,6 +10,7 @@
   </category>
   <category label="32464">
     <setting id="auto_seek" type="bool" label="32466" default="true" />
+    <setting id="auto_seek_delay" subsetting="true" enable="eq(-1,true)" type="slider" label="32487" default="0" range="0,.1,5" option="float" />
     <setting id="kodi_skip_stepping" type="bool" label="32465" default="false" />
     <setting id="dynamic_timeline_seek" type="bool" label="32471" default="false" />
   </category>


### PR DESCRIPTION
GHI (If applicable): None

## Description:
The new seek behavior allows seek after a delay but the delay is a hardwired constant.  This changes the seek delay to a setting including shortcut behavior in the seek should the delay be 0.

## Checklist:
- [X] I have based this PR against the develop branch
