### PR TITLE
Put locks around access to UI elements from main and other threads.

### DIFF
--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -311,6 +311,8 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         self.updateHubs = {}
         windowutils.HOME = self
 
+        self.lock = threading.Lock()
+
         util.setGlobalBoolProperty('off.sections', '')
 
     def onFirstInit(self):
@@ -537,16 +539,17 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
             for task in self.tasks:
                 task.cancel()
 
-        self.setProperty('hub.focus', '')
-        self.displayServerAndUser()
-        if not plexapp.SERVERMANAGER.selectedServer:
-            self.setFocusId(self.USER_BUTTON_ID)
-            return False
-
-        self.showSections()
-        self.backgroundSet = False
-        self.showHubs(HomeSection)
-        return True
+        with self.lock:
+            self.setProperty('hub.focus', '')
+            self.displayServerAndUser()
+            if not plexapp.SERVERMANAGER.selectedServer:
+                self.setFocusId(self.USER_BUTTON_ID)
+                return False
+    
+            self.showSections()
+            self.backgroundSet = False
+            self.showHubs(HomeSection)
+            return True
 
     def hubItemClicked(self, hubControlID, auto_play=False):
         control = self.hubControls[hubControlID - 400]
@@ -649,33 +652,36 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         self._sectionReallyChanged()
 
     def _sectionReallyChanged(self):
-        section = self.lastSection
-        self.setProperty('hub.focus', '')
-        util.DEBUG_LOG('Section changed ({0}): {1}'.format(section.key, repr(section.title)))
-        self.showHubs(section)
-        self.lastSection = section
-        self.checkSectionItem(force=True)
+        with self.lock:
+            section = self.lastSection
+            self.setProperty('hub.focus', '')
+            util.DEBUG_LOG('Section changed ({0}): {1}'.format(section.key, repr(section.title)))
+            self.showHubs(section)
+            self.lastSection = section
+            self.checkSectionItem(force=True)
 
     def sectionHubsCallback(self, section, hubs):
-        update = bool(self.sectionHubs.get(section.key))
-        self.sectionHubs[section.key] = hubs
-        if self.lastSection == section:
-            self.showHubs(section, update=update)
+        with self.lock:
+            update = bool(self.sectionHubs.get(section.key))
+            self.sectionHubs[section.key] = hubs
+            if self.lastSection == section:
+                self.showHubs(section, update=update)
 
     def updateHubCallback(self, hub, items=None):
-        for mli in self.sectionList:
-            section = mli.dataSource
-            if not section:
-                continue
-
-            hubs = self.sectionHubs.get(section.key, ())
-            for idx, ihub in enumerate(hubs):
-                if ihub == hub:
-                    if self.lastSection == section:
-                        util.DEBUG_LOG('Hub {0} updated - refreshing section: {1}'.format(hub.hubIdentifier, repr(section.title)))
-                        hubs[idx] = hub
-                        self.showHub(hub, items=items)
-                        return
+        with self.lock:
+            for mli in self.sectionList:
+                section = mli.dataSource
+                if not section:
+                    continue
+    
+                hubs = self.sectionHubs.get(section.key, ())
+                for idx, ihub in enumerate(hubs):
+                    if ihub == hub:
+                        if self.lastSection == section:
+                            util.DEBUG_LOG('Hub {0} updated - refreshing section: {1}'.format(hub.hubIdentifier, repr(section.title)))
+                            hubs[idx] = hub
+                            self.showHub(hub, items=items)
+                            return
 
     def extendHubCallback(self, hub, items):
         self.updateHubCallback(hub, items)


### PR DESCRIPTION
GHI (If applicable): None

## Description:
I was seeing cases where hubs were incompletely rendered.  A hub that has 20 items across only shows 1, 2, 3, etc…  Additionally, I was seeing crashes when exiting PfK and the two seemed to be linked.  Putting locks around the concurrent access point between the main thread and the background worker threads appears to have resolved both issues.

PR best viewed by ignoring whitespace.

## Checklist:
- [X] I have based this PR against the develop branch
