### PR TITLE
Fixed string comparisons to use `String.IsEqual`.

### DIFF
--- a/resources/skins/Main/1080i/script-plex-album.xml
+++ b/resources/skins/Main/1080i/script-plex-album.xml
@@ -156,7 +156,7 @@
                             <posx>120</posx>
                             <posy>24</posy>
                             <control type="label">
-                                <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                <visible>!String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                 <posx>-10</posx>
                                 <posy>0</posy>
                                 <width>60</width>
@@ -168,7 +168,7 @@
                                 <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                             </control>
                             <control type="image">
-                                <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                <visible>String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                 <posx>2</posx>
                                 <posy>21</posy>
                                 <width>35</width>
@@ -237,7 +237,7 @@
                                 <posx>120</posx>
                                 <posy>24</posy>
                                 <control type="label">
-                                    <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>!String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>-10</posx>
                                     <posy>0</posy>
                                     <width>60</width>
@@ -249,7 +249,7 @@
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                                 </control>
                                 <control type="image">
-                                    <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>2</posx>
                                     <posy>21</posy>
                                     <width>35</width>
@@ -314,7 +314,7 @@
                                     <colordiffuse>FFE5A00D</colordiffuse>
                                 </control>
                                 <control type="label">
-                                    <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>!String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>48</posx>
                                     <posy>0</posy>
                                     <width>50</width>
@@ -326,7 +326,7 @@
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                                 </control>
                                 <control type="image">
-                                    <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>36</posx>
                                     <posy>21</posy>
                                     <width>35</width>

--- a/resources/skins/Main/1080i/script-plex-dropdown.xml
+++ b/resources/skins/Main/1080i/script-plex-dropdown.xml
@@ -34,12 +34,12 @@
                 <posy>0</posy>
                 <width>300</width>
                 <height>924</height>
-                <onup condition="StringCompare(Window.Property(close.direction),top)">Close</onup>
-                <onup condition="!StringCompare(Window.Property(close.direction),top)">noop</onup>
-                <onleft condition="StringCompare(Window.Property(close.direction),left)">Close</onleft>
-                <onright condition="StringCompare(Window.Property(close.direction),right)">Close</onright>
-                <ondown condition="StringCompare(Window.Property(close.direction),down)">Close</ondown>
-                <ondown condition="!StringCompare(Window.Property(close.direction),down)">noop</ondown>
+                <onup condition="String.IsEqual(Window.Property(close.direction),top)">Close</onup>
+                <onup condition="!String.IsEqual(Window.Property(close.direction),top)">noop</onup>
+                <onleft condition="String.IsEqual(Window.Property(close.direction),left)">Close</onleft>
+                <onright condition="String.IsEqual(Window.Property(close.direction),right)">Close</onright>
+                <ondown condition="String.IsEqual(Window.Property(close.direction),down)">Close</ondown>
+                <ondown condition="!String.IsEqual(Window.Property(close.direction),down)">noop</ondown>
                 <scrolltime>200</scrolltime>
                 <orientation>vertical</orientation>
                 <!-- ITEM LAYOUT ########################################## -->

--- a/resources/skins/Main/1080i/script-plex-dropdown_header.xml
+++ b/resources/skins/Main/1080i/script-plex-dropdown_header.xml
@@ -56,12 +56,12 @@
                 <posy>0</posy>
                 <width>600</width>
                 <height>924</height>
-                <onup condition="StringCompare(Window.Property(close.direction),top)">Close</onup>
-                <onup condition="!StringCompare(Window.Property(close.direction),top)">noop</onup>
-                <onleft condition="StringCompare(Window.Property(close.direction),left)">Close</onleft>
-                <onright condition="StringCompare(Window.Property(close.direction),right)">Close</onright>
-                <ondown condition="StringCompare(Window.Property(close.direction),down)">Close</ondown>
-                <ondown condition="!StringCompare(Window.Property(close.direction),down)">noop</ondown>
+                <onup condition="String.IsEqual(Window.Property(close.direction),top)">Close</onup>
+                <onup condition="!String.IsEqual(Window.Property(close.direction),top)">noop</onup>
+                <onleft condition="String.IsEqual(Window.Property(close.direction),left)">Close</onleft>
+                <onright condition="String.IsEqual(Window.Property(close.direction),right)">Close</onright>
+                <ondown condition="String.IsEqual(Window.Property(close.direction),down)">Close</ondown>
+                <ondown condition="!String.IsEqual(Window.Property(close.direction),down)">noop</ondown>
                 <scrolltime>200</scrolltime>
                 <orientation>vertical</orientation>
                 <!-- ITEM LAYOUT ########################################## -->

--- a/resources/skins/Main/1080i/script-plex-listview-16x9-chunked.xml
+++ b/resources/skins/Main/1080i/script-plex-listview-16x9-chunked.xml
@@ -257,7 +257,7 @@
                 </control>
 
                 <control type="scrollbar" id="152">
-                    <visible>!StringCompare(Window(10000).Property(script.plex.item.type),episode)</visible>
+                    <visible>!String.IsEqual(Window(10000).Property(script.plex.item.type),episode)</visible>
                     <hitrect x="1108" y="33" w="90" h="879" />
                     <left>1128</left>
                     <top>33</top>
@@ -277,7 +277,7 @@
                     <onleft>151</onleft>
                 </control>
                 <control type="group">
-                    <visible>StringCompare(Window(10000).Property(script.plex.item.type),episode)</visible>
+                    <visible>String.IsEqual(Window(10000).Property(script.plex.item.type),episode)</visible>
                     <left>1128</left>
                     <top>33</top>
                     <width>10</width>
@@ -406,7 +406,7 @@
             <posx>60</posx>
             <posy>248</posy>
             <control type="image">
-                <visible>!StringCompare(Window.Property(media),show)</visible>
+                <visible>!String.IsEqual(Window.Property(media),show)</visible>
                 <posx>0</posx>
                 <posy>0</posy>
                 <width>630</width>
@@ -416,7 +416,7 @@
                 <aspectratio>scale</aspectratio>
             </control>
             <control type="image">
-                <visible>StringCompare(Window.Property(media),show)</visible>
+                <visible>String.IsEqual(Window.Property(media),show)</visible>
                 <posx>0</posx>
                 <posy>0</posy>
                 <width>630</width>
@@ -468,7 +468,7 @@
         </control>
 
         <control type="group" id="150">
-            <visible>StringCompare(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+            <visible>String.IsEqual(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
             <defaultcontrol>151</defaultcontrol>
             <posx>1830</posx>
             <posy>150</posy>
@@ -492,7 +492,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -504,7 +504,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -538,7 +538,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -550,7 +550,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -793,7 +793,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(filter1.display)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="310">
-                    <visible>!StringCompare(Window.Property(media),show)</visible>
+                    <visible>!String.IsEqual(Window.Property(media),show)</visible>
                     <enable>false</enable>
                     <width max="300">auto</width>
                     <height>65</height>
@@ -810,7 +810,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(media.type)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="312">
-                    <visible>StringCompare(Window.Property(media),show)</visible>
+                    <visible>String.IsEqual(Window.Property(media),show)</visible>
                     <width max="300">auto</width>
                     <height>65</height>
                     <font>font12</font>

--- a/resources/skins/Main/1080i/script-plex-listview-16x9.xml
+++ b/resources/skins/Main/1080i/script-plex-listview-16x9.xml
@@ -30,7 +30,7 @@
             <posx>60</posx>
             <posy>248</posy>
             <control type="image">
-                <visible>!StringCompare(Window.Property(media),show)</visible>
+                <visible>!String.IsEqual(Window.Property(media),show)</visible>
                 <posx>0</posx>
                 <posy>0</posy>
                 <width>630</width>
@@ -40,7 +40,7 @@
                 <aspectratio>scale</aspectratio>
             </control>
             <control type="image">
-                <visible>StringCompare(Window.Property(media),show)</visible>
+                <visible>String.IsEqual(Window.Property(media),show)</visible>
                 <posx>0</posx>
                 <posy>0</posy>
                 <width>630</width>
@@ -420,7 +420,7 @@
         </control>
 
         <control type="group" id="150">
-            <visible>StringCompare(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+            <visible>String.IsEqual(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
             <defaultcontrol>151</defaultcontrol>
             <posx>1830</posx>
             <posy>150</posy>
@@ -444,7 +444,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -456,7 +456,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -490,7 +490,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -502,7 +502,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -745,7 +745,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(filter1.display)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="310">
-                    <visible>!StringCompare(Window.Property(media),show)</visible>
+                    <visible>!String.IsEqual(Window.Property(media),show)</visible>
                     <enable>false</enable>
                     <width max="300">auto</width>
                     <height>65</height>
@@ -762,7 +762,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(media.type)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="312">
-                    <visible>StringCompare(Window.Property(media),show)</visible>
+                    <visible>String.IsEqual(Window.Property(media),show)</visible>
                     <width max="300">auto</width>
                     <height>65</height>
                     <font>font12</font>

--- a/resources/skins/Main/1080i/script-plex-listview-square-chunked.xml
+++ b/resources/skins/Main/1080i/script-plex-listview-square-chunked.xml
@@ -300,7 +300,7 @@
                 </control>
 
                 <control type="scrollbar" id="152">
-                    <visible>!StringCompare(Window(10000).Property(script.plex.item.type),album)</visible>
+                    <visible>!String.IsEqual(Window(10000).Property(script.plex.item.type),album)</visible>
                     <hitrect x="1108" y="33" w="90" h="879" />
                     <left>1128</left>
                     <top>33</top>
@@ -320,7 +320,7 @@
                     <onleft>151</onleft>
                 </control>
                 <control type="group">
-                    <visible>StringCompare(Window(10000).Property(script.plex.item.type),album)</visible>
+                    <visible>String.IsEqual(Window(10000).Property(script.plex.item.type),album)</visible>
                     <left>1128</left>
                     <top>33</top>
                     <width>10</width>
@@ -449,7 +449,7 @@
             <posx>60</posx>
             <posy>248</posy>
             <control type="group">
-                <visible>StringCompare(Window.Property(media),photo) | StringCompare(Window.Property(media),photodirectory)</visible>
+                <visible>String.IsEqual(Window.Property(media),photo) | String.IsEqual(Window.Property(media),photodirectory)</visible>
                 <control type="image">
                     <posx>0</posx>
                     <posy>0</posy>
@@ -468,7 +468,7 @@
                 </control>
             </control>
             <control type="image">
-                <visible>StringCompare(Window.Property(media),artist)</visible>
+                <visible>String.IsEqual(Window.Property(media),artist)</visible>
                 <posx>0</posx>
                 <posy>0</posy>
                 <width>355</width>
@@ -537,7 +537,7 @@
         </control>
 
         <control type="group" id="150">
-            <visible>StringCompare(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+            <visible>String.IsEqual(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
             <defaultcontrol>151</defaultcontrol>
             <posx>1830</posx>
             <posy>150</posy>
@@ -561,7 +561,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -573,7 +573,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -607,7 +607,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -619,7 +619,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -862,7 +862,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(filter1.display)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="310">
-                    <visible>!StringCompare(Window.Property(media),artist)</visible>
+                    <visible>!String.IsEqual(Window.Property(media),artist)</visible>
                     <enable>false</enable>
                     <width max="300">auto</width>
                     <height>65</height>
@@ -879,7 +879,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(media.type)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="312">
-                    <visible>StringCompare(Window.Property(media),artist)</visible>
+                    <visible>String.IsEqual(Window.Property(media),artist)</visible>
                     <width max="300">auto</width>
                     <height>65</height>
                     <font>font12</font>

--- a/resources/skins/Main/1080i/script-plex-listview-square.xml
+++ b/resources/skins/Main/1080i/script-plex-listview-square.xml
@@ -30,7 +30,7 @@
             <posx>60</posx>
             <posy>248</posy>
             <control type="group">
-                <visible>StringCompare(Window.Property(media),photo) | StringCompare(Window.Property(media),photodirectory)</visible>
+                <visible>String.IsEqual(Window.Property(media),photo) | String.IsEqual(Window.Property(media),photodirectory)</visible>
                 <control type="image">
                     <posx>0</posx>
                     <posy>0</posy>
@@ -49,7 +49,7 @@
                 </control>
             </control>
             <control type="image">
-                <visible>StringCompare(Window.Property(media),artist)</visible>
+                <visible>String.IsEqual(Window.Property(media),artist)</visible>
                 <posx>0</posx>
                 <posy>0</posy>
                 <width>355</width>
@@ -489,7 +489,7 @@
         </control>
 
         <control type="group" id="150">
-            <visible>StringCompare(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+            <visible>String.IsEqual(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
             <defaultcontrol>151</defaultcontrol>
             <posx>1830</posx>
             <posy>150</posy>
@@ -513,7 +513,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -525,7 +525,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -559,7 +559,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -571,7 +571,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -814,7 +814,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(filter1.display)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="310">
-                    <visible>!StringCompare(Window.Property(media),artist)</visible>
+                    <visible>!String.IsEqual(Window.Property(media),artist)</visible>
                     <enable>false</enable>
                     <width max="300">auto</width>
                     <height>65</height>
@@ -831,7 +831,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(media.type)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="312">
-                    <visible>StringCompare(Window.Property(media),artist)</visible>
+                    <visible>String.IsEqual(Window.Property(media),artist)</visible>
                     <width max="300">auto</width>
                     <height>65</height>
                     <font>font12</font>

--- a/resources/skins/Main/1080i/script-plex-music_current_playlist.xml
+++ b/resources/skins/Main/1080i/script-plex-music_current_playlist.xml
@@ -148,7 +148,7 @@
                             <posx>120</posx>
                             <posy>24</posy>
                             <control type="label">
-                                <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                <visible>!String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                 <posx>-10</posx>
                                 <posy>0</posy>
                                 <width>60</width>
@@ -160,7 +160,7 @@
                                 <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                             </control>
                             <control type="image">
-                                <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                <visible>String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                 <posx>2</posx>
                                 <posy>32.5</posy>
                                 <width>35</width>
@@ -233,7 +233,7 @@
                                 <posx>120</posx>
                                 <posy>24</posy>
                                 <control type="label">
-                                    <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>!String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>-10</posx>
                                     <posy>0</posy>
                                     <width>60</width>
@@ -245,7 +245,7 @@
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                                 </control>
                                 <control type="image">
-                                    <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>0</posx>
                                     <posy>32.5</posy>
                                     <width>35</width>
@@ -329,7 +329,7 @@
                                     <colordiffuse>FFE5A00D</colordiffuse>
                                 </control>
                                 <control type="label">
-                                    <visible>!StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>!String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>24</posx>
                                     <posy>0</posy>
                                     <width>60</width>
@@ -341,7 +341,7 @@
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                                 </control>
                                 <control type="image">
-                                    <visible>StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>36</posx>
                                     <posy>32.5</posy>
                                     <width>35</width>

--- a/resources/skins/Main/1080i/script-plex-photo.xml
+++ b/resources/skins/Main/1080i/script-plex-photo.xml
@@ -27,8 +27,8 @@
             </control>
             <control type="image" id="600">
                 <!-- Doesn't work for all aspects -->
-                <!-- <animation effect="zoom" start="56" end="100" time="200" center="960,540" reversible="false" condition="StringCompare(Window.Property(rotate),90) | StringCompare(Window.Property(rotate),270)">Conditional</animation>
-                <animation effect="zoom" start="178" end="100" time="200" center="960,540" reversible="false" condition="StringCompare(Window.Property(rotate),0) | StringCompare(Window.Property(rotate),180)">Conditional</animation> -->
+                <!-- <animation effect="zoom" start="56" end="100" time="200" center="960,540" reversible="false" condition="String.IsEqual(Window.Property(rotate),90) | String.IsEqual(Window.Property(rotate),270)">Conditional</animation>
+                <animation effect="zoom" start="178" end="100" time="200" center="960,540" reversible="false" condition="String.IsEqual(Window.Property(rotate),0) | String.IsEqual(Window.Property(rotate),180)">Conditional</animation> -->
                 <animation effect="rotate" time="200" start="0" end="90" center="960,540" reversible="false" condition="Integer.IsGreater(Window.Property(rotate),89)">Conditional</animation>
                 <animation effect="rotate" time="200" start="0" end="90" center="960,540" reversible="false" condition="Integer.IsGreater(Window.Property(rotate),179)">Conditional</animation>
                 <animation effect="rotate" time="200" start="0" end="90" center="960,540" reversible="false" condition="Integer.IsGreater(Window.Property(rotate),269)">Conditional</animation>

--- a/resources/skins/Main/1080i/script-plex-playlist.xml
+++ b/resources/skins/Main/1080i/script-plex-playlist.xml
@@ -155,7 +155,7 @@
                             <posx>120</posx>
                             <posy>24</posy>
                             <control type="label">
-                                <visible>String.IsEmpty(ListItem.Property(track.ID)) | !StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                <visible>String.IsEmpty(ListItem.Property(track.ID)) | !String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                 <posx>-10</posx>
                                 <posy>0</posy>
                                 <width>60</width>
@@ -167,7 +167,7 @@
                                 <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                             </control>
                             <control type="image">
-                                <visible>!String.IsEmpty(ListItem.Property(track.ID)) + StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                <visible>!String.IsEmpty(ListItem.Property(track.ID)) + String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                 <posx>2</posx>
                                 <posy>32.5</posy>
                                 <width>35</width>
@@ -288,7 +288,7 @@
                                 <posx>120</posx>
                                 <posy>24</posy>
                                 <control type="label">
-                                    <visible>String.IsEmpty(ListItem.Property(track.ID)) | !StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>String.IsEmpty(ListItem.Property(track.ID)) | !String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>-10</posx>
                                     <posy>0</posy>
                                     <width>60</width>
@@ -300,7 +300,7 @@
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                                 </control>
                                 <control type="image">
-                                    <visible>!String.IsEmpty(ListItem.Property(track.ID)) + StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>!String.IsEmpty(ListItem.Property(track.ID)) + String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>0</posx>
                                     <posy>32.5</posy>
                                     <width>35</width>
@@ -449,7 +449,7 @@
                                     <colordiffuse>99FFFFFF</colordiffuse>
                                 </control>-->
                                 <control type="label">
-                                    <visible>String.IsEmpty(ListItem.Property(track.ID)) | !StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>String.IsEmpty(ListItem.Property(track.ID)) | !String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>24</posx>
                                     <posy>0</posy>
                                     <width>60</width>
@@ -461,7 +461,7 @@
                                     <label>[B]$INFO[ListItem.Property(track.number)][/B]</label>
                                 </control>
                                 <control type="image">
-                                    <visible>!String.IsEmpty(ListItem.Property(track.ID)) + StringCompare(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
+                                    <visible>!String.IsEmpty(ListItem.Property(track.ID)) + String.IsEqual(ListItem.Property(track.ID),Window(10000).Property(script.plex.track.ID))</visible>
                                     <posx>36</posx>
                                     <posy>32.5</posy>
                                     <width>35</width>

--- a/resources/skins/Main/1080i/script-plex-posters.xml
+++ b/resources/skins/Main/1080i/script-plex-posters.xml
@@ -345,7 +345,7 @@
         </control>
 
         <control type="group" id="150">
-            <visible>StringCompare(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+            <visible>String.IsEqual(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
             <defaultcontrol>151</defaultcontrol>
             <posx>1780</posx>
             <posy>150</posy>
@@ -369,7 +369,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -381,7 +381,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -415,7 +415,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -427,7 +427,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -699,7 +699,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(filter1.display)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="310">
-                    <visible>!StringCompare(Window.Property(media),show)</visible>
+                    <visible>!String.IsEqual(Window.Property(media),show)</visible>
                     <enable>false</enable>
                     <width max="300">auto</width>
                     <height>65</height>
@@ -716,7 +716,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(media.type)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="312">
-                    <visible>StringCompare(Window.Property(media),show)</visible>
+                    <visible>String.IsEqual(Window.Property(media),show)</visible>
                     <width max="300">auto</width>
                     <height>65</height>
                     <font>font12</font>

--- a/resources/skins/Main/1080i/script-plex-search.xml
+++ b/resources/skins/Main/1080i/script-plex-search.xml
@@ -79,7 +79,7 @@
                         <texture colordiffuse="FF1F1F1F">script.plex/white-square.png</texture>
                     </control>
                     <control type="group">
-                        <visible>StringCompare(Window.Property(search.section),all)</visible>
+                        <visible>String.IsEqual(Window.Property(search.section),all)</visible>
                         <control type="image">
                             <posx>0</posx>
                             <posy>0</posy>
@@ -102,7 +102,7 @@
                     </control>
                     <control type="label">
                         <scroll>false</scroll>
-                        <visible>!StringCompare(Window.Property(search.section),all)</visible>
+                        <visible>!String.IsEqual(Window.Property(search.section),all)</visible>
                         <posx>0</posx>
                         <posy>0</posy>
                         <width>151</width>
@@ -125,7 +125,7 @@
                         <texture colordiffuse="FF1F1F1F">script.plex/white-square.png</texture>
                     </control>
                     <control type="image">
-                        <visible>StringCompare(Window.Property(search.section),movie)</visible>
+                        <visible>String.IsEqual(Window.Property(search.section),movie)</visible>
                         <posx>0</posx>
                         <posy>0</posy>
                         <width>74</width>
@@ -144,7 +144,7 @@
                         <texture colordiffuse="FF1F1F1F">script.plex/white-square.png</texture>
                     </control>
                     <control type="image">
-                        <visible>StringCompare(Window.Property(search.section),show)</visible>
+                        <visible>String.IsEqual(Window.Property(search.section),show)</visible>
                         <posx>0</posx>
                         <posy>0</posy>
                         <width>74</width>
@@ -163,7 +163,7 @@
                         <texture colordiffuse="FF1F1F1F">script.plex/white-square.png</texture>
                     </control>
                     <control type="image">
-                        <visible>StringCompare(Window.Property(search.section),artist)</visible>
+                        <visible>String.IsEqual(Window.Property(search.section),artist)</visible>
                         <posx>0</posx>
                         <posy>0</posy>
                         <width>74</width>
@@ -182,7 +182,7 @@
                         <texture colordiffuse="FF1F1F1F">script.plex/white-square.png</texture>
                     </control>
                     <control type="image">
-                        <visible>StringCompare(Window.Property(search.section),photo)</visible>
+                        <visible>String.IsEqual(Window.Property(search.section),photo)</visible>
                         <posx>0</posx>
                         <posy>0</posy>
                         <width>74</width>

--- a/resources/skins/Main/1080i/script-plex-squares.xml
+++ b/resources/skins/Main/1080i/script-plex-squares.xml
@@ -267,7 +267,7 @@
         </control>
 
         <control type="group" id="150">
-            <visible>StringCompare(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
+            <visible>String.IsEqual(Window(10000).Property(script.plex.sort),titleSort) + Integer.IsGreater(Container(101).NumItems,0) + String.IsEmpty(Window.Property(drawing))</visible>
             <defaultcontrol>151</defaultcontrol>
             <posx>1780</posx>
             <posy>150</posy>
@@ -291,7 +291,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -303,7 +303,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -337,7 +337,7 @@
                             <posx>0</posx>
                             <posy>0</posy>
                             <control type="label">
-                                <visible>!StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
+                                <visible>!String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(letter))</visible>
                                 <posx>0</posx>
                                 <posy>0</posy>
                                 <width>34</width>
@@ -349,7 +349,7 @@
                                 <label>$INFO[ListItem.Label]</label>
                             </control>
                             <control type="group">
-                                <visible>StringCompare(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
+                                <visible>String.IsEqual(Window(10000).Property(script.plex.key), ListItem.Property(key))</visible>
                                 <control type="image">
                                     <posx>0</posx>
                                     <posy>0</posy>
@@ -621,7 +621,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(filter1.display)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="310">
-                    <visible>!StringCompare(Window.Property(media),artist)</visible>
+                    <visible>!String.IsEqual(Window.Property(media),artist)</visible>
                     <enable>false</enable>
                     <width max="300">auto</width>
                     <height>65</height>
@@ -638,7 +638,7 @@
                     <label>[UPPERCASE]$INFO[Window.Property(media.type)][/UPPERCASE]</label>
                 </control>
                 <control type="button" id="312">
-                    <visible>StringCompare(Window.Property(media),artist)</visible>
+                    <visible>String.IsEqual(Window.Property(media),artist)</visible>
                     <width max="300">auto</width>
                     <height>65</height>
                     <font>font12</font>


### PR DESCRIPTION
GHI (If applicable): #265

## Description:
`StringCompare` was already deprecated and removed in Kodi 18.  `String.IsEqual` is its replacement.

## Checklist:
- [X] I have based this PR against the develop branch
