### PR TITLE
Added HD Audio support (currently only TrueHD)

### DIFF
--- a/lib/_included_packages/plexnet/plexplayer.py
+++ b/lib/_included_packages/plexnet/plexplayer.py
@@ -251,7 +251,7 @@ class PlexPlayer(object):
             # Global variables for all decisions
             decisionPath = http.addUrlParam(decisionPath, "mediaBufferSize=20971") # Kodi default is 20971520 (20MB)
             decisionPath = http.addUrlParam(decisionPath, "hasMDE=1")
-            decisionPath = http.addUrlParam(decisionPath, 'X-Plex-Platform=Chrome')
+            decisionPath = http.addUrlParam(decisionPath, 'X-Plex-Platform=Generic')
 
         return decisionPath
 
@@ -332,14 +332,24 @@ class PlexPlayer(object):
             else:
                 numChannels = 8
 
-            for codec in ("ac3", "eac3", "dca"):
-                if self.item.settings.supportsAudioStream(codec, numChannels):
-                    builder.extras.append("append-transcode-target-audio-codec(type=videoProfile&context=streaming&audioCodec=" + codec + ")")
-                    builder.extras.append("add-direct-play-profile(type=videoProfile&container=matroska&videoCodec=*&audioCodec=" + codec + ")")
-                    if codec == "dca":
-                        builder.extras.append(
-                            "add-limitation(scope=videoAudioCodec&scopeName=dca&type=upperBound&name=audio.channels&value=8&isRequired=false)"
-                        )
+            codecs = ("ac3", "eac3", "dca")
+            if self.item.settings.getPreference("allow_hd_audio", False):
+                codecs += "truehd",
+            
+            builder.extras.append("add-transcode-target(type=videoProfile&context=streaming&protocol=http&container=mkv&videoCodec=h264&audioCodec=" + ",".join(codecs) + ")")
+
+            # for codec in codecs:
+            #     if self.item.settings.supportsAudioStream(codec, numChannels):
+            #         builder.extras.append("append-transcode-target-audio-codec(type=videoProfile&context=streaming&audioCodec=" + codec + ")")
+            #         builder.extras.append("add-direct-play-profile(type=videoProfile&container=matroska&videoCodec=*&audioCodec=" + codec + ")")
+            #         if codec == "dca":
+            #             builder.extras.append(
+            #                 "add-limitation(scope=videoAudioCodec&scopeName=dca&type=upperBound&name=audio.channels&value=8&isRequired=false)"
+            #             )
+            #         if codec == "truehd":
+            #             builder.extras.append(
+            #                 "add-limitation(scope=videoAudioCodec&scopeName=truhd&type=upperBound&name=audio.channels&value=12&isRequired=false)"
+            #             )
 
         # AAC sample rate cannot be less than 22050hz (HLS is capable).
         if self.choice.audioStream is not None and self.choice.audioStream.samplingRate.asInt(22050) < 22050:

--- a/lib/windows/settings.py
+++ b/lib/windows/settings.py
@@ -193,8 +193,9 @@ class Settings(object):
             )
         ),
         'audio': (
-            T(32048, 'Audio'),
-            ()
+            T(32048, 'Audio'), (
+                BoolSetting('allow_hd_audio', T(32058, 'Allow HD Audio'), False),
+            )
         ),
         'video': (
             T(32053, 'Video'), (
@@ -257,7 +258,7 @@ class Settings(object):
         ),
     }
 
-    SECTION_IDS = ('main', 'video', 'subtitles', 'advanced', 'manual', 'about')
+    SECTION_IDS = ('main', 'video', 'audio', 'subtitles', 'advanced', 'manual', 'about')
 
     def __getitem__(self, key):
         return self.SETTINGS[key]

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -225,6 +225,9 @@ msgctxt "#32057"
 msgid "Current Server Version"
 msgstr ""
 
+msgctxt "#32058"
+msgid "Allow HD Audio"
+msgstr ""
 
 msgctxt "#32100"
 msgid "Skip user selection and pin entry on startup."


### PR DESCRIPTION
GHI (If applicable): #

## Description:

This seeks to enable support for HD audio direct streaming when transcoding video.

It may not be possible to merge this in without amendments due to the change in X-Plex-Platform, however the default Chrome profile doesn't allow audio above 2 channels.

## Checklist:
- [ ] I have based this PR against the develop branch
