### PR TITLE
Add option to fix forced subtitles handling in PMS

### DIFF
--- a/lib/_included_packages/plexnet/plexstream.py
+++ b/lib/_included_packages/plexnet/plexstream.py
@@ -132,7 +132,7 @@ class PlexStream(plexobjects.PlexObject):
         if self.__class__ != other.__class__:
             return False
 
-        for attr in ("streamType", "language", "codec", "channels", "index"):
+        for attr in ("streamType", "language", "codec", "channels", "index", "key"):
             if getattr(self, attr) != getattr(other, attr):
                 return False
 

--- a/lib/player.py
+++ b/lib/player.py
@@ -373,7 +373,8 @@ class SeekPlayerHandler(BasePlayerHandler):
         # self.showOSD(from_seek=True)
 
     def setSubtitles(self):
-        subs = self.player.video.selectedSubtitleStream()
+        subs = self.player.video.selectedSubtitleStream(
+            forced_subtitles_override=util.advancedSettings.forcedSubtitlesOverride)
         if subs:
             xbmc.sleep(100)
             self.player.showSubtitles(False)

--- a/lib/util.py
+++ b/lib/util.py
@@ -88,6 +88,7 @@ class AdvancedSettings(object):
         ("kodi_skip_stepping", False),
         ("auto_seek", True),
         ("dynamic_timeline_seek", False),
+        ("forced_subtitles_override", False),
         ("fast_back", False),
     )
 

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -734,7 +734,7 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         sas = video.selectedAudioStream()
         mli.setProperty('audio', sas and sas.getTitle(metadata.apiTranslate) or T(32309, 'None'))
 
-        sss = video.selectedSubtitleStream()
+        sss = video.selectedSubtitleStream(forced_subtitles_override=util.advancedSettings.forcedSubtitlesOverride)
         if sss:
             if len(video.subtitleStreams) > 1:
                 mli.setProperty(

--- a/lib/windows/playersettings.py
+++ b/lib/windows/playersettings.py
@@ -105,7 +105,8 @@ class VideoSettingsDialog(kodigui.BaseDialog, util.CronReceiver):
         sas = self.video.selectedAudioStream()
         audio = sas and sas.getTitle(metadata.apiTranslate) or T(32309, 'None')
 
-        sss = self.video.selectedSubtitleStream()
+        sss = self.video.selectedSubtitleStream(
+            forced_subtitles_override=util.advancedSettings.forcedSubtitlesOverride)
         if sss:
             if len(self.video.subtitleStreams) > 1:
                 subtitle = u'{0} \u2022 {1} {2}'.format(sss.getTitle(metadata.apiTranslate), len(self.video.subtitleStreams) - 1, T(32307, 'More'))
@@ -253,6 +254,7 @@ def showSubtitlesDialog(video, non_playback=False):
         return
 
     video.selectStream(choice)
+    video.manually_selected_sub_stream = choice.id
 
 
 def showQualityDialog(video, non_playback=False, selected_idx=None):

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -522,7 +522,8 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         sas = self.video.selectedAudioStream()
         self.setProperty('audio', sas and sas.getTitle(metadata.apiTranslate) or T(32309, 'None'))
 
-        sss = self.video.selectedSubtitleStream()
+        sss = self.video.selectedSubtitleStream(
+            forced_subtitles_override=util.advancedSettings.forcedSubtitlesOverride)
         if sss:
             if len(self.video.subtitleStreams) > 1:
                 self.setProperty(

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -510,8 +510,12 @@ class SeekDialog(kodigui.BaseDialog):
             self.initialAudioStream = self.player.video.selectedAudioStream()
             changed = True
 
-        if self.player.video.selectedSubtitleStream() != self.initialSubtitleStream:
-            self.initialSubtitleStream = self.player.video.selectedSubtitleStream()
+        if self.player.video.selectedSubtitleStream(
+                forced_subtitles_override=util.advancedSettings.forcedSubtitlesOverride
+        ) != self.initialSubtitleStream:
+            self.initialSubtitleStream = \
+                self.player.video.selectedSubtitleStream(
+                    forced_subtitles_override=util.advancedSettings.forcedSubtitlesOverride)
             if changed or self.handler.mode == self.handler.MODE_RELATIVE:
                 return True
             else:

--- a/lib/windows/subitems.py
+++ b/lib/windows/subitems.py
@@ -151,7 +151,8 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         sas = self.mediaItem.selectedAudioStream()
         self.setProperty('audio', sas and sas.getTitle() or 'None')
 
-        sss = self.mediaItem.selectedSubtitleStream()
+        sss = self.mediaItem.selectedSubtitleStream(
+            forced_subtitles_override=util.advancedSettings.forcedSubtitlesOverride)
         self.setProperty('subtitles', sss and sss.getTitle() or 'None')
 
         leafcount = self.mediaItem.leafCount.asFloat()

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -978,3 +978,7 @@ msgstr ""
 msgctxt "#32492"
 msgid "Kodi Subtitle Settings"
 msgstr ""
+
+msgctxt "#32493"
+msgid "Prefer normal over forced subtitles if available (PMS selects forced by default)"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -12,6 +12,7 @@
     <setting id="auto_seek" type="bool" label="32466" default="true" />
     <setting id="kodi_skip_stepping" type="bool" label="32465" default="false" />
     <setting id="dynamic_timeline_seek" type="bool" label="32471" default="false" />
+    <setting id="forced_subtitles_override" type="bool" label="32493" default="false" />
   </category>
   <category label="32467">
     <setting id="fast_back" type="bool" label="32485" default="false" />


### PR DESCRIPTION
GHI (If applicable): #

## Description:
The PMS has a long standing issue, that it pre-selects forced subtitles over full subtitles. I've reported that ages ago and it hasn't been fixed since. The PMS should have an option to disable this behaviour.

It's arguably wrong for a client to fix this; but as an option that's off by default, this is IMHO OK.

When there is a media file with both forced and normal subtitles for the same language and the user hasn't explicitly selected the forced one, select the non-forced one by default (external have precedence over embedded, to keep the same behaviour as the PMS).

## Checklist:
- [x] I have based this PR against the develop branch
