### PR TITLE
Kodi 19/Python 3 compatibility

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -4,8 +4,8 @@
        version="0.1.7a3"
        provider-name="Plex">
     <requires>
-        <import addon="xbmc.python" version="2.25.0"/>
-        <import addon="script.module.requests" version="2.3.0"/>
+        <import addon="xbmc.python" version="2.26.0"/>
+        <import addon="script.module.requests" />
         <import addon="script.module.six" />
         <import addon="script.module.kodi-six" />
     </requires>

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.plex"
        name="Plex"
-       version="0.1.7a4"
+       version="0.1.7a3"
        provider-name="Plex">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -4,7 +4,7 @@
        version="0.1.7a3"
        provider-name="Plex">
     <requires>
-        <import addon="xbmc.python" version="2.26.0"/>
+        <import addon="xbmc.python" version="3"/>
         <import addon="script.module.requests" />
         <import addon="script.module.six" />
         <import addon="script.module.kodi-six" />

--- a/addon.xml
+++ b/addon.xml
@@ -6,6 +6,8 @@
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.requests" version="2.3.0"/>
+        <import addon="script.module.six" />
+        <import addon="script.module.kodi-six" />
     </requires>
     <extension point="xbmc.python.script" library="default.py">
         <provides>video</provides>

--- a/addon.xml
+++ b/addon.xml
@@ -4,7 +4,7 @@
        version="0.1.7a3"
        provider-name="Plex">
     <requires>
-        <import addon="xbmc.python" version="3"/>
+        <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.22.0" />
         <import addon="script.module.six" version="1.14.0" />
         <import addon="script.module.kodi-six" version="0.1.3.1" />

--- a/addon.xml
+++ b/addon.xml
@@ -5,9 +5,9 @@
        provider-name="Plex">
     <requires>
         <import addon="xbmc.python" version="3"/>
-        <import addon="script.module.requests" />
-        <import addon="script.module.six" />
-        <import addon="script.module.kodi-six" />
+        <import addon="script.module.requests" version="2.22.0" />
+        <import addon="script.module.six" version="1.14.0" />
+        <import addon="script.module.kodi-six" version="0.1.3.1" />
     </requires>
     <extension point="xbmc.python.script" library="default.py">
         <provides>video</provides>

--- a/default.py
+++ b/default.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from lib import main
 
 

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import requests
 
 # Disable some warnings. These are not security issue warnings, but alerts to issues that may cause errors
@@ -8,5 +9,5 @@ except:
     import traceback
     traceback.print_exc()
 
-import compat
-import _included_packages
+from . import compat
+from . import _included_packages

--- a/lib/_included_packages/__init__.py
+++ b/lib/_included_packages/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import sys
 import inspect

--- a/lib/_included_packages/plexnet/asyncadapter.py
+++ b/lib/_included_packages/plexnet/asyncadapter.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import time
 import socket
 
@@ -8,7 +9,7 @@ from requests.packages.urllib3.connectionpool import VerifiedHTTPSConnection
 from requests.adapters import HTTPAdapter
 from requests.compat import urlparse
 
-from httplib import HTTPConnection
+from six.moves.http_client import HTTPConnection
 import errno
 
 DEFAULT_POOLBLOCK = False

--- a/lib/_included_packages/plexnet/audio.py
+++ b/lib/_included_packages/plexnet/audio.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-import plexobjects
-import plexmedia
-import media
+from __future__ import absolute_import
+from . import plexobjects
+from . import plexmedia
+from . import media
 
 
 class Audio(media.MediaItem):
@@ -125,7 +126,7 @@ class Track(Audio):
     @property
     def settings(self):
         if not self._settings:
-            import plexapp
+            from . import plexapp
             self._settings = plexapp.PlayerSettingsInterface()
 
         return self._settings

--- a/lib/_included_packages/plexnet/audioobject.py
+++ b/lib/_included_packages/plexnet/audioobject.py
@@ -1,6 +1,7 @@
-import http
-import mediadecisionengine
-import util
+from __future__ import absolute_import
+from . import http
+from . import mediadecisionengine
+from . import util
 
 
 class AudioObjectClass(object):

--- a/lib/_included_packages/plexnet/callback.py
+++ b/lib/_included_packages/plexnet/callback.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import threading
 
 
@@ -37,7 +38,7 @@ class Callable(object):
 
     @property
     def context(self):
-        return self.func.im_self
+        return self.func.__self__
 
     @classmethod
     def nextID(cls):

--- a/lib/_included_packages/plexnet/captions.py
+++ b/lib/_included_packages/plexnet/captions.py
@@ -1,10 +1,11 @@
-import plexapp
-import util
+from __future__ import absolute_import
+from . import plexapp
+from . import util
 
 
 class Captions(object):
     def __init__(self):
-        self.deviceInfo = plexapp.INTERFACE.getGlobal("deviceInfo")
+        self.deviceInfo = util.INTERFACE.getGlobal("deviceInfo")
 
         self.textSize = util.AttributeDict({
             'extrasmall': 15,

--- a/lib/_included_packages/plexnet/compat.py
+++ b/lib/_included_packages/plexnet/compat.py
@@ -4,22 +4,23 @@ Python 2/3 compatability
 Always try Py3 first
 """
 
+from __future__ import absolute_import
 try:
     from urllib.parse import urlencode
 except ImportError:
-    from urllib import urlencode
+    from six.moves.urllib.parse import urlencode
 
 try:
     from urllib.parse import quote
 except ImportError:
-    from urllib import quote
+    from six.moves.urllib.parse import quote
 
 try:
     from urllib.parse import quote_plus
 except ImportError:
-    from urllib import quote_plus
+    from six.moves.urllib.parse import quote_plus
 
 try:
     from configparser import ConfigParser
 except ImportError:
-    from ConfigParser import ConfigParser
+    from six.moves.configparser import ConfigParser

--- a/lib/_included_packages/plexnet/gdm.py
+++ b/lib/_included_packages/plexnet/gdm.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 import threading
 import socket
 import traceback
 import time
-import util
-import netif
+from . import util
+from . import netif
 
-import plexconnection
+from . import plexconnection
 
 DISCOVERY_PORT = 32414
 WIN_NL = chr(13) + chr(10)
@@ -24,15 +25,15 @@ class GDMDiscovery(object):
     #     util.LOG('GDMDiscovery().discover() - NOT IMPLEMENTED')
 
     def isActive(self):
-        import plexapp
-        return plexapp.INTERFACE.getPreference("gdm_discovery", True) and self.thread and self.thread.isAlive()
+        from . import plexapp
+        return util.INTERFACE.getPreference("gdm_discovery", True) and self.thread and self.thread.isAlive()
 
     '''
     def discover(self):
         # Only allow discovery if enabled and not currently running
         self._close = False
         import plexapp
-        if not plexapp.INTERFACE.getPreference("gdm_discovery", True) or self.isActive():
+        if not util.INTERFACE.getPreference("gdm_discovery", True) or self.isActive():
             return
 
         ifaces = netif.getInterfaces()
@@ -109,7 +110,7 @@ class GDMDiscovery(object):
             self.timer = plexapp.createTimer(5000, self.onTimer)
             self.socket = udp
             Application().AddSocketCallback(udp, createCallable("OnSocketEvent", m))
-            plexapp.APP.addTimer(self.timer)
+            util.APP.addTimer(self.timer)
         else:
             util.ERROR_LOG("Failed to send GDM discovery message")
             import plexapp
@@ -120,8 +121,8 @@ class GDMDiscovery(object):
     '''
 
     def discover(self):
-        import plexapp
-        if not plexapp.INTERFACE.getPreference("gdm_discovery", True) or self.isActive():
+        from . import plexapp
+        if not util.INTERFACE.getPreference("gdm_discovery", True) or self.isActive():
             return
 
         self.thread = threading.Thread(target=self._discover)
@@ -132,7 +133,7 @@ class GDMDiscovery(object):
         sockets = []
         self.servers = []
 
-        packet = "M-SEARCH * HTTP/1.1" + WIN_NL + WIN_NL
+        packet = ("M-SEARCH * HTTP/1.1" + WIN_NL + WIN_NL).encode("utf-8")
 
         for i in ifaces:
             if not i.broadcast:
@@ -190,7 +191,7 @@ class GDMDiscovery(object):
         if not name or not machineID:
             return
 
-        import plexserver
+        from . import plexserver
         conn = plexconnection.PlexConnection(plexconnection.PlexConnection.SOURCE_DISCOVERED, "http://" + hostname + ":" + port, True, None, bool(secureHost))
         server = plexserver.createPlexServerForConnection(conn)
         server.uuid = machineID
@@ -216,7 +217,7 @@ class GDMDiscovery(object):
 
         if self.servers:
             util.LOG("Finished GDM discovery, found {0} server(s)".format(len(self.servers)))
-            import plexapp
+            from . import plexapp
             plexapp.SERVERMANAGER.updateFromConnectionType(self.servers, plexconnection.PlexConnection.SOURCE_DISCOVERED)
             self.servers = None
 

--- a/lib/_included_packages/plexnet/locks.py
+++ b/lib/_included_packages/plexnet/locks.py
@@ -3,7 +3,8 @@
 #  * Locks().Lock("lockName")      : creates virtual lock
 #  * Locks().IsLocked("lockName")  : returns true if locked
 #  * Locks().Unlock("lockName")    : return true if existed & removed
-import util
+from __future__ import absolute_import
+from . import util
 
 
 class Locks(object):

--- a/lib/_included_packages/plexnet/media.py
+++ b/lib/_included_packages/plexnet/media.py
@@ -1,7 +1,7 @@
-import plexobjects
-import plexstream
-import plexrequest
-import util
+from __future__ import absolute_import
+from . import plexobjects
+from . import plexstream
+from . import util
 
 METADATA_RELATED_TRAILER = 1
 METADATA_RELATED_DELETED_SCENE = 2
@@ -50,6 +50,7 @@ class MediaItem(plexobjects.PlexObject):
         if not self.ratingKey:
             return
 
+        from . import plexrequest
         req = plexrequest.PlexRequest(self.server, '/library/metadata/{0}'.format(self.ratingKey), method='DELETE')
         req.getToStringWithTimeout(10)
         self.deleted = req.wasOK()
@@ -97,8 +98,8 @@ class MediaPart(plexobjects.PlexObject):
         return '<%s:%s>' % (self.__class__.__name__, self.id)
 
     def selectedStream(self, stream_type):
-        streams = filter(lambda x: stream_type == x.type, self.streams)
-        selected = list(filter(lambda x: x.selected is True, streams))
+        streams = [x for x in self.streams if stream_type == x.type]
+        selected = list([x for x in streams if x.selected is True])
         if len(selected) == 0:
             return None
         return selected[0]

--- a/lib/_included_packages/plexnet/mediachoice.py
+++ b/lib/_included_packages/plexnet/mediachoice.py
@@ -1,5 +1,6 @@
-import plexstream
-import util
+from __future__ import absolute_import
+from . import plexstream
+from . import util
 
 
 class MediaChoice(object):

--- a/lib/_included_packages/plexnet/mediadecisionengine.py
+++ b/lib/_included_packages/plexnet/mediadecisionengine.py
@@ -1,7 +1,10 @@
-import mediachoice
-import serverdecision
-import plexapp
-import util
+from __future__ import absolute_import
+from . import mediachoice
+from . import serverdecision
+from . import plexapp
+from . import util
+import six
+from six.moves import range
 
 
 class MediaDecisionEngine(object):
@@ -309,7 +312,7 @@ class MediaDecisionEngine(object):
         # return False
 
     def evaluateSubtitles(self, stream):
-        if plexapp.INTERFACE.getPreference("burn_subtitles") == "always":
+        if util.INTERFACE.getPreference("burn_subtitles") == "always":
             # If the user prefers them burned, always burn
             return mediachoice.MediaChoice.SUBTITLES_BURN
         # elif stream.codec != "srt":
@@ -440,7 +443,7 @@ class MediaDecisionEngine(object):
 
         if key is None:
             choices.sort()
-        elif isinstance(key, basestring):
+        elif isinstance(key, six.string_types):
             choices.sort(key=lambda x: getattr(x.media, key))
         elif hasattr(key, '__call__'):
             choices.sort(key=key)
@@ -460,13 +463,13 @@ class MediaDecisionEngine(object):
         return 0
 
     def isSupported4k(self, media, videoStream):
-        if videoStream is None or not plexapp.INTERFACE.getPreference("allow_4k", True):
+        if videoStream is None or not util.INTERFACE.getPreference("allow_4k", True):
             return False
 
         # # Roku 4 only: H.265/HEVC (MKV, MP4, MOV); VP9 (.MKV)
         # if media.get('container') in ("mp4", "mov", "m4v", "mkv"):
-        #     isHEVC = (videoStream.codec == "hevc" and plexapp.INTERFACE.getPreference("allow_hevc"))
-        #     isVP9 = (videoStream.codec == "vp9" and media.get('container') == "mkv" and plexapp.INTERFACE.getGlobal("vp9Support"))
+        #     isHEVC = (videoStream.codec == "hevc" and util.INTERFACE.getPreference("allow_hevc"))
+        #     isVP9 = (videoStream.codec == "vp9" and media.get('container') == "mkv" and util.INTERFACE.getGlobal("vp9Support"))
         #     return (isHEVC or isVP9)
 
         # return False

--- a/lib/_included_packages/plexnet/myplex.py
+++ b/lib/_included_packages/plexnet/myplex.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
-import util
-import http
+from __future__ import absolute_import
+from . import util
+from . import http
 from threading import Thread
 from xml.etree import ElementTree
 import time
 
-import exceptions
+from . import exceptions
 
-import video
-import audio
-import photo
+from . import video
+from . import audio
+from . import photo
 
 video, audio, photo  # Hides warning message
 
@@ -44,7 +45,7 @@ class PinLogin(object):
             while not self._abort and time.time() - start < 300:
                 try:
                     response = http.GET(self.POLL.format(self.id))
-                except Exception, e:
+                except Exception as e:
                     util.ERROR('PinLogin connection error: {0}'.format(e.__class__), err=e)
                     time.sleep(self.POLL_INTERVAL)
                     continue
@@ -54,7 +55,7 @@ class PinLogin(object):
                     break
                 try:
                     data = ElementTree.fromstring(response.text.encode('utf-8'))
-                except Exception, e:
+                except Exception as e:
                     util.ERROR('PinLogin data error: {0}'.format(e.__class__), err=e)
                     time.sleep(self.POLL_INTERVAL)
                     continue

--- a/lib/_included_packages/plexnet/myplexaccount.py
+++ b/lib/_included_packages/plexnet/myplexaccount.py
@@ -1,15 +1,16 @@
+from __future__ import absolute_import
 import json
 import time
 import hashlib
 from xml.etree import ElementTree
 
-import plexapp
-import myplexrequest
-import locks
-import callback
-import asyncadapter
+from . import plexapp
+from . import myplexrequest
+from . import locks
+from . import callback
+from . import asyncadapter
 
-import util
+from . import util
 
 ACCOUNT = None
 
@@ -31,7 +32,7 @@ class MyPlexAccount(object):
         self.thumb = None
 
         # Booleans
-        self.isAuthenticated = plexapp.INTERFACE.getPreference('auto_signin', False)
+        self.isAuthenticated = util.INTERFACE.getPreference('auto_signin', False)
         self.isSignedIn = False
         self.isOffline = False
         self.isExpired = False
@@ -66,15 +67,15 @@ class MyPlexAccount(object):
             'adminHasPlexPass': self.adminHasPlexPass
         }
 
-        plexapp.INTERFACE.setRegistry("MyPlexAccount", json.dumps(obj), "myplex")
+        util.INTERFACE.setRegistry("MyPlexAccount", json.dumps(obj), "myplex")
 
     def loadState(self):
         # Look for the new JSON serialization. If it's not there, look for the
         # old token and Plex Pass values.
 
-        plexapp.APP.addInitializer("myplex")
+        util.APP.addInitializer("myplex")
 
-        jstring = plexapp.INTERFACE.getRegistry("MyPlexAccount", None, "myplex")
+        jstring = util.INTERFACE.getRegistry("MyPlexAccount", None, "myplex")
 
         if jstring:
             try:
@@ -100,9 +101,9 @@ class MyPlexAccount(object):
         if self.authToken:
             request = myplexrequest.MyPlexRequest("/users/account")
             context = request.createRequestContext("account", callback.Callable(self.onAccountResponse))
-            plexapp.APP.startRequest(request, context)
+            util.APP.startRequest(request, context)
         else:
-            plexapp.APP.clearInitializer("myplex")
+            util.APP.clearInitializer("myplex")
 
     def logState(self):
         util.LOG("Authenticated as {0}:{1}".format(self.ID, repr(self.title)))
@@ -163,7 +164,7 @@ class MyPlexAccount(object):
             self.logState()
 
             self.saveState()
-            plexapp.MANAGER.publish()
+            util.MANAGER.publish()
             plexapp.refreshResources()
         elif response.getStatus() >= 400 and response.getStatus() < 500:
             # The user is specifically unauthorized, clear everything
@@ -178,14 +179,14 @@ class MyPlexAccount(object):
             if not self.isAuthenticated and not self.isProtected:
                 self.isAuthenticated = True
 
-        plexapp.APP.clearInitializer("myplex")
+        util.APP.clearInitializer("myplex")
         # Logger().UpdateSyslogHeader()  # TODO: ------------------------------------------------------------------------------------------------------IMPLEMENT
 
         if oldId != self.ID or self.switchUser:
             self.switchUser = None
-            plexapp.APP.trigger("change:user", account=self, reallyChanged=oldId != self.ID)
+            util.APP.trigger("change:user", account=self, reallyChanged=oldId != self.ID)
 
-        plexapp.APP.trigger("account:response")
+        util.APP.trigger("account:response")
 
     def signOut(self, expired=False):
         # Strings
@@ -206,15 +207,15 @@ class MyPlexAccount(object):
         self.isExpired = expired
 
         # Clear the saved resources
-        plexapp.INTERFACE.clearRegistry("mpaResources", "xml_cache")
+        util.INTERFACE.clearRegistry("mpaResources", "xml_cache")
 
         # Remove all saved servers
         plexapp.SERVERMANAGER.clearServers()
 
         # Enable the welcome screen again
-        plexapp.INTERFACE.setPreference("show_welcome", True)
+        util.INTERFACE.setPreference("show_welcome", True)
 
-        plexapp.APP.trigger("change:user", account=self, reallyChanged=True)
+        util.APP.trigger("change:user", account=self, reallyChanged=True)
 
         self.saveState()
 
@@ -232,7 +233,7 @@ class MyPlexAccount(object):
         context = request.createRequestContext("sign_in", callback.Callable(self.onAccountResponse))
         if self.isOffline:
             context.timeout = self.isOffline and asyncadapter.AsyncTimeout(1).setConnectTimeout(1)
-        plexapp.APP.startRequest(request, context, {})
+        util.APP.startRequest(request, context, {})
 
     def refreshAccount(self):
         if not self.authToken:

--- a/lib/_included_packages/plexnet/myplexmanager.py
+++ b/lib/_included_packages/plexnet/myplexmanager.py
@@ -1,27 +1,28 @@
+from __future__ import absolute_import
 from xml.etree import ElementTree
-import urllib
+import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 
-import plexapp
-import plexconnection
-import plexserver
-import myplexrequest
-import callback
-import util
+from . import plexapp
+from . import plexconnection
+from . import plexserver
+from . import myplexrequest
+from . import callback
+from . import util
 
 
 class MyPlexManager(object):
     def publish(self):
         util.LOG('MyPlexManager().publish() - NOT IMPLEMENTED')
         return  # TODO: ----------------------------------------------------------------------------------------------------------------------------- IMPLEMENT?
-        request = myplexrequest.MyPlexRequest("/devices/" + plexapp.INTERFACE.getGlobal("clientIdentifier"))
+        request = myplexrequest.MyPlexRequest("/devices/" + util.INTERFACE.getGlobal("clientIdentifier"))
         context = request.createRequestContext("publish")
 
-        addrs = plexapp.INTERFACE.getGlobal("roDeviceInfo").getIPAddrs()
+        addrs = util.INTERFACE.getGlobal("roDeviceInfo").getIPAddrs()
 
         for iface in addrs:
-            request.addParam(urllib.quote("Connection[][uri]"), "http://{0):8324".format(addrs[iface]))
+            request.addParam(six.moves.urllib.parse.quote("Connection[][uri]"), "http://{0):8324".format(addrs[iface]))
 
-        plexapp.APP.startRequest(request, context, "_method=PUT")
+        util.APP.startRequest(request, context, "_method=PUT")
 
     def refreshResources(self, force=False):
         if force:
@@ -33,7 +34,7 @@ class MyPlexManager(object):
         if plexapp.ACCOUNT.isSecure:
             request.addParam("includeHttps", "1")
 
-        plexapp.APP.startRequest(request, context)
+        util.APP.startRequest(request, context)
 
     def onResourcesResponse(self, request, response, context):
         servers = []
@@ -42,11 +43,11 @@ class MyPlexManager(object):
 
         # Save the last successful response to cache
         if response.isSuccess() and response.event:
-            plexapp.INTERFACE.setRegistry("mpaResources", response.event.text.encode('utf-8'), "xml_cache")
+            util.INTERFACE.setRegistry("mpaResources", response.event.text.encode('utf-8'), "xml_cache")
             util.DEBUG_LOG("Saved resources response to registry")
         # Load the last successful response from cache
-        elif plexapp.INTERFACE.getRegistry("mpaResources", None, "xml_cache"):
-            data = ElementTree.fromstring(plexapp.INTERFACE.getRegistry("mpaResources", None, "xml_cache"))
+        elif util.INTERFACE.getRegistry("mpaResources", None, "xml_cache"):
+            data = ElementTree.fromstring(util.INTERFACE.getRegistry("mpaResources", None, "xml_cache"))
             response.parseFakeXMLResponse(data)
             util.DEBUG_LOG("Using cached resources")
 

--- a/lib/_included_packages/plexnet/myplexrequest.py
+++ b/lib/_included_packages/plexnet/myplexrequest.py
@@ -1,11 +1,12 @@
 # We don't particularly need a class definition here (yet?), it's just a
 # PlexRequest where the server is fixed.
-import plexrequest
+from __future__ import absolute_import
+from . import plexrequest
 
 
 class MyPlexRequest(plexrequest.PlexServerRequest):
     def __init__(self, path):
-        import myplexserver
+        from . import myplexserver
         plexrequest.PlexServerRequest.__init__(self, myplexserver.MyPlexServer(), path)
 
         # Make sure we're always getting XML

--- a/lib/_included_packages/plexnet/myplexserver.py
+++ b/lib/_included_packages/plexnet/myplexserver.py
@@ -1,8 +1,9 @@
-import plexapp
-import plexconnection
-import plexserver
-import plexresource
-import plexservermanager
+from __future__ import absolute_import
+from . import plexapp
+from . import plexconnection
+from . import plexserver
+from . import plexresource
+from . import plexservermanager
 
 
 class MyPlexServer(plexserver.PlexServer):

--- a/lib/_included_packages/plexnet/netif/__init__.py
+++ b/lib/_included_packages/plexnet/netif/__init__.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 import socket
 import struct
+from six.moves import range
 
 class Interface:
     def __init__(self):
@@ -51,7 +53,7 @@ def _getInterfaces():
 def _getInterfacesBSD():
     #name flags family address netmask
     interfaces = []
-    import getifaddrs
+    from . import getifaddrs
     for info in getifaddrs.getifaddrs():
         if info.family == 2:
             i = Interface()
@@ -62,7 +64,7 @@ def _getInterfacesBSD():
     return interfaces
 
 def _getInterfacesWin():
-    import ipconfig
+    from . import ipconfig
     interfaces = []
     adapters = ipconfig.parse()
     for a in adapters:

--- a/lib/_included_packages/plexnet/netif/getifaddrs.py
+++ b/lib/_included_packages/plexnet/netif/getifaddrs.py
@@ -2,11 +2,14 @@
 Wrapper for getifaddrs(3).
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import socket
 import sys
 
 from collections import namedtuple
 from ctypes import *
+from six.moves import map
 
 class sockaddr_in(Structure):
     _fields_ = [
@@ -88,8 +91,8 @@ class sockaddr(Union):
         elif family == 18:  # AF_LINK
             return str(self.sa_sdl)
         else:
-            print family
-            raise NotImplementedError, "address family %d not supported" % family
+            print(family)
+            raise NotImplementedError("address family %d not supported" % family)
 
 
 class ifaddrs(Structure):

--- a/lib/_included_packages/plexnet/netif/ipconfig.py
+++ b/lib/_included_packages/plexnet/netif/ipconfig.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+from __future__ import print_function
 import subprocess
 
 def parse(data=None):
@@ -34,7 +36,7 @@ def parse(data=None):
                 v = d.replace('(Preferred)','')
                 sections[-1][k] += ',' + v.strip()
         except:
-            print d
+            print(d)
             raise
 
     return sections[1:]

--- a/lib/_included_packages/plexnet/nowplayingmanager.py
+++ b/lib/_included_packages/plexnet/nowplayingmanager.py
@@ -1,14 +1,15 @@
 # Most of this is ported from Roku code and much of it is currently unused
 # TODO: Perhaps remove unnecessary code
+from __future__ import absolute_import
 import time
 
-import util
-import urllib
-import urlparse
-import plexapp
-import plexrequest
-import callback
-import http
+from . import util
+from six import moves
+import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
+import six.moves.urllib.parse
+from . import plexrequest
+from . import callback
+from . import http
 
 
 class ServerTimeline(util.AttributeDict):
@@ -87,7 +88,7 @@ class TimelineData(util.AttributeDict):
                 elem.attrib["machineIdentifier"] = server.uuid
 
                 if server.activeConnection:
-                    parts = urlparse.uslparse(server.activeConnection.address)
+                    parts = six.moves.urllib.parse.uslparse(server.activeConnection.address)
                     elem.attrib["protocol"] = parts.scheme
                     elem.attrib["address"] = parts.netloc.split(':', 1)[0]
                     if ':' in parts.netloc:
@@ -186,12 +187,13 @@ class NowPlayingManager(object):
         path = "/:/timeline"
         for paramKey in params:
             if params[paramKey]:
-                path = http.addUrlParam(path, paramKey + "=" + urllib.quote(str(params[paramKey])))
+                path = http.addUrlParam(path, paramKey + "=" + six.moves.urllib.parse.quote(str(params[paramKey])))
 
         request = plexrequest.PlexRequest(timeline.item.getServer(), path)
         context = request.createRequestContext("timelineUpdate", callback.Callable(self.onTimelineResponse))
         context.playQueue = timeline.playQueue
-        plexapp.APP.startRequest(request, context)
+        from . import plexapp
+        util.APP.startRequest(request, context)
 
     def getServerTimeline(self, timelineType):
         if not self.serverTimelines.get(timelineType):

--- a/lib/_included_packages/plexnet/photo.py
+++ b/lib/_included_packages/plexnet/photo.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-import media
-import plexobjects
-import plexmedia
+from __future__ import absolute_import
+from . import media
+from . import plexobjects
+from . import plexmedia
 
 
 class Photo(media.MediaItem):

--- a/lib/_included_packages/plexnet/playlist.py
+++ b/lib/_included_packages/plexnet/playlist.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
 import random
 
-import plexobjects
-import signalsmixin
+from . import plexobjects
+from . import signalsmixin
+from six.moves import range
 
 
 class BasePlaylist(plexobjects.PlexObject, signalsmixin.SignalsMixin):
@@ -80,6 +82,8 @@ class BasePlaylist(plexobjects.PlexObject, signalsmixin.SignalsMixin):
 
         return True
 
+    __next__ = next
+
     def prev(self):
         if not self.hasPrev():
             return False
@@ -127,7 +131,7 @@ class BasePlaylist(plexobjects.PlexObject, signalsmixin.SignalsMixin):
 
     def shuffle(self, on=True, first=False):
         if on and self._items:
-            self._shuffle = range(len(self._items))
+            self._shuffle = list(range(len(self._items)))
             random.shuffle(self._shuffle)
             if not first:
                 self.pos = self._shuffle.index(self.pos)

--- a/lib/_included_packages/plexnet/playqueue.py
+++ b/lib/_included_packages/plexnet/playqueue.py
@@ -1,13 +1,15 @@
+from __future__ import absolute_import
 import re
-import urllib
+import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 import time
 
-import plexapp
-import plexrequest
-import callback
-import plexobjects
-import util
-import signalsmixin
+from . import plexapp
+from . import plexrequest
+from . import callback
+from . import plexobjects
+from . import util
+from . import signalsmixin
+from six.moves import range
 
 
 class AudioUsage(object):
@@ -262,12 +264,12 @@ class PlayQueue(signalsmixin.SignalsMixin):
 
                 if not self.refreshTimer:
                     self.refreshTimer = plexapp.createTimer(5000, self.onRefreshTimer)
-                    plexapp.APP.addTimer(self.refreshTimer)
+                    util.APP.addTimer(self.refreshTimer)
             else:
                 request = plexrequest.PlexRequest(self.server, "/playQueues/" + str(self.id))
                 self.addRequestOptions(request)
                 context = request.createRequestContext("refresh", callback.Callable(self.onResponse))
-                plexapp.APP.startRequest(request, context)
+                util.APP.startRequest(request, context)
 
         if wait:
             return self.waitForInitialization()
@@ -292,7 +294,7 @@ class PlayQueue(signalsmixin.SignalsMixin):
         request = plexrequest.PlexRequest(self.server, "/playQueues/" + str(self.id) + command, "PUT")
         self.addRequestOptions(request)
         context = request.createRequestContext("shuffle", callback.Callable(self.onResponse))
-        plexapp.APP.startRequest(request, context)
+        util.APP.startRequest(request, context)
 
     def setRepeat(self, repeat, one=False):
         if self.isRepeat == repeat and self.isRepeatOne == one:
@@ -335,7 +337,7 @@ class PlayQueue(signalsmixin.SignalsMixin):
         request = plexrequest.PlexRequest(self.server, "/playQueues/" + str(self.id) + "/items/" + item.get("playQueueItemID", "-1") + "/move" + query, "PUT")
         self.addRequestOptions(request)
         context = request.createRequestContext("move", callback.Callable(self.onResponse))
-        plexapp.APP.startRequest(request, context)
+        util.APP.startRequest(request, context)
 
     def swapItem(self, index, delta=1):
         before = self._items[index]
@@ -348,7 +350,7 @@ class PlayQueue(signalsmixin.SignalsMixin):
         request = plexrequest.PlexRequest(self.server, "/playQueues/" + str(self.id) + "/items/" + item.get("playQueueItemID", "-1"), "DELETE")
         self.addRequestOptions(request)
         context = request.createRequestContext("delete", callback.Callable(self.onResponse))
-        plexapp.APP.startRequest(request, context)
+        util.APP.startRequest(request, context)
 
     def addItem(self, item, addNext=False, excludeSeedItem=False):
         request = plexrequest.PlexRequest(self.server, "/playQueues/" + str(self.id), "PUT")
@@ -357,7 +359,7 @@ class PlayQueue(signalsmixin.SignalsMixin):
         request.addParam("excludeSeedItem", excludeSeedItem and "1" or "0")
         self.addRequestOptions(request)
         context = request.createRequestContext("add", callback.Callable(self.onResponse))
-        plexapp.APP.startRequest(request, context)
+        util.APP.startRequest(request, context)
 
     def onResponse(self, request, response, context):
         # Close any loading modal regardless of response status
@@ -471,14 +473,14 @@ class PlayQueue(signalsmixin.SignalsMixin):
         if self.isRepeatOne:
             return True
 
-        if not self.allowSkipNext and -1 < self.items().index(self.current()) < (len(self.items()) - 1):  # TODO: Was 'or' - did change cause issues?
+        if not self.allowSkipNext and -1 < list(self.items()).index(self.current()) < (len(list(self.items())) - 1):  # TODO: Was 'or' - did change cause issues?
             return self.isRepeat and not self.isWindowed()
 
         return True
 
     def hasPrev(self):
         # return self.allowSkipPrev or self.items().index(self.current()) > 0
-        return self.items().index(self.current()) > 0
+        return list(self.items()).index(self.current()) > 0
 
     def next(self):
         if not self.hasNext():
@@ -487,13 +489,13 @@ class PlayQueue(signalsmixin.SignalsMixin):
         if self.isRepeatOne:
             return self.current()
 
-        pos = self.items().index(self.current()) + 1
-        if pos >= len(self.items()):
+        pos = list(self.items()).index(self.current()) + 1
+        if pos >= len(list(self.items())):
             if not self.isRepeat or self.isWindowed():
                 return None
             pos = 0
 
-        item = self.items()[pos]
+        item = list(self.items())[pos]
         self.selectedId = item.playQueueItemID.asInt()
         return item
 
@@ -502,16 +504,16 @@ class PlayQueue(signalsmixin.SignalsMixin):
             return None
         if self.isRepeatOne:
             return self.current()
-        pos = self.items().index(self.current()) - 1
-        item = self.items()[pos]
+        pos = list(self.items()).index(self.current()) - 1
+        item = list(self.items())[pos]
         self.selectedId = item.playQueueItemID.asInt()
         return item
 
     def setCurrent(self, pos):
-        if pos < 0 or pos >= len(self.items()):
+        if pos < 0 or pos >= len(list(self.items())):
             return False
 
-        item = self.items()[pos]
+        item = list(self.items())[pos]
         self.selectedId = item.playQueueItemID.asInt()
         return item
 
@@ -619,7 +621,7 @@ def createRemotePlayQueue(item, contentType, options, args):
         options.context = options.CONTEXT_SELF
     elif item.type == "movie":
         if not options.extrasPrefixCount and not options.resume:
-            options.extrasPrefixCount = plexapp.INTERFACE.getPreference("cinema_trailers", 0)
+            options.extrasPrefixCount = util.INTERFACE.getPreference("cinema_trailers", 0)
 
     # How exactly to construct the item URI depends on the metadata type, though
     # whenever possible we simply use /library/metadata/:id.
@@ -678,7 +680,7 @@ def createRemotePlayQueue(item, contentType, options, args):
                 path = regex.sub("\1" + convert[key] + "=", path)
 
         util.DEBUG_LOG("playQueue path: " + str(path))
-        uri = uri + itemType + "/" + urllib.quote_plus(path)
+        uri = uri + itemType + "/" + six.moves.urllib.parse.quote_plus(path)
 
     util.DEBUG_LOG("playQueue uri: " + str(uri))
 
@@ -687,7 +689,7 @@ def createRemotePlayQueue(item, contentType, options, args):
 
     request.addParam(not options.isPlaylist and "uri" or "playlistID", uri)
     request.addParam("type", contentType)
-    # request.addParam('X-Plex-Client-Identifier', plexapp.INTERFACE.getGlobal('clientIdentifier'))
+    # request.addParam('X-Plex-Client-Identifier', util.INTERFACE.getGlobal('clientIdentifier'))
 
     # Add options we pass once during PQ creation
     if options.shuffle:
@@ -704,7 +706,7 @@ def createRemotePlayQueue(item, contentType, options, args):
 
     util.DEBUG_LOG('Initial playQueue request started...')
     context = request.createRequestContext("create", callback.Callable(obj.onResponse))
-    plexapp.APP.startRequest(request, context, body='')
+    util.APP.startRequest(request, context, body='')
 
     return obj
 
@@ -717,7 +719,7 @@ def createPlayQueueForId(id, server=None, contentType=None):
     request.addParam("own", "1")
     obj.addRequestOptions(request)
     context = request.createRequestContext("own", callback.Callable(obj.onResponse))
-    plexapp.APP.startRequest(request, context)
+    util.APP.startRequest(request, context)
 
     return obj
 

--- a/lib/_included_packages/plexnet/plexapp.py
+++ b/lib/_included_packages/plexnet/plexapp.py
@@ -1,13 +1,14 @@
+from __future__ import print_function, absolute_import
 import threading
 import platform
 import uuid
 import sys
-import callback
 
-import signalsmixin
-import simpleobjects
-import nowplayingmanager
-import util
+from . import callback
+from . import signalsmixin
+from . import simpleobjects
+from . import nowplayingmanager
+from . import util
 
 Res = simpleobjects.Res
 
@@ -22,11 +23,11 @@ PLATFORM = util.X_PLEX_DEVICE
 
 def init():
     global MANAGER, SERVERMANAGER, ACCOUNT
-    import myplexaccount
+    from . import myplexaccount
     ACCOUNT = myplexaccount.ACCOUNT
-    import plexservermanager
+    from . import plexservermanager
     SERVERMANAGER = plexservermanager.MANAGER
-    import myplexmanager
+    from . import myplexmanager
     MANAGER = myplexmanager.MANAGER
     ACCOUNT.init()
 
@@ -99,7 +100,7 @@ class App(signalsmixin.SignalsMixin):
             timer.cancel()
 
     def preShutdown(self):
-        import http
+        from . import http
         http.HttpRequest._cancel = True
         if self.pendingRequests:
             util.DEBUG_LOG('Closing down {0} App() requests...'.format(len(self.pendingRequests)))
@@ -352,7 +353,7 @@ class DumbInterface(AppInterface):
         return ''
 
     def LOG(self, msg):
-        print 'PlexNet.API: {0}'.format(msg)
+        print('PlexNet.API: {0}'.format(msg))
 
     def DEBUG_LOG(self, msg):
         self.LOG('DEBUG: {0}'.format(msg))
@@ -468,12 +469,12 @@ def setUserAgent(agent):
 
 
 def setAbortFlagFunction(func):
-    import asyncadapter
+    from . import asyncadapter
     asyncadapter.ABORT_FLAG_FUNCTION = func
 
 
 def refreshResources(force=False):
-    import gdm
+    from . import gdm
     gdm.DISCOVERY.discover()
     MANAGER.refreshResources(force)
     SERVERMANAGER.refreshManualConnections()

--- a/lib/_included_packages/plexnet/plexconnection.py
+++ b/lib/_included_packages/plexnet/plexconnection.py
@@ -1,9 +1,9 @@
+from __future__ import absolute_import
 import random
 
-import http
-import plexapp
-import callback
-import util
+from . import http
+from . import callback
+from . import util
 
 
 class ConnectionSource(int):
@@ -110,7 +110,7 @@ class PlexConnection(object):
 
         allowConnectionTest = not self.isFallback
         if not allowConnectionTest:
-            insecurePolicy = plexapp.INTERFACE.getPreference("allow_insecure")
+            insecurePolicy = util.INTERFACE.getPreference("allow_insecure")
             if insecurePolicy == "always" or (insecurePolicy == "same_network" and server.sameNetwork and self.isLocal):
                 allowConnectionTest = allowFallback
                 server.hasFallback = not allowConnectionTest
@@ -139,7 +139,7 @@ class PlexConnection(object):
             context = self.request.createRequestContext("reachability", callback.Callable(self.onReachabilityResponse))
             context.server = server
             util.addPlexHeaders(self.request, server.getToken())
-            self.hasPendingRequest = plexapp.APP.startRequest(self.request, context)
+            self.hasPendingRequest = util.APP.startRequest(self.request, context)
             return True
 
         return False

--- a/lib/_included_packages/plexnet/plexlibrary.py
+++ b/lib/_included_packages/plexnet/plexlibrary.py
@@ -2,12 +2,14 @@
 """
 PlexLibrary
 """
-import plexobjects
-import playlist
-import media
-import exceptions
-import util
-import signalsmixin
+from __future__ import absolute_import
+from . import plexobjects
+from . import playlist
+from . import media
+from . import exceptions
+from . import util
+from . import signalsmixin
+from six.moves import map
 
 
 class Library(plexobjects.PlexObject):
@@ -105,7 +107,7 @@ class LibrarySection(plexobjects.PlexObject):
         key = self.key
         try:
             data = self.server.query(initpath, params=kwargs)
-        except Exception, e:
+        except Exception as e:
             import traceback
             traceback.print_exc()
             util.ERROR(err=e)
@@ -289,7 +291,7 @@ class LibrarySection(plexobjects.PlexObject):
                 continue
             matches = [k for t, k in lookup.items() if item in t]
             if matches:
-                map(result.add, matches)
+                list(map(result.add, matches))
                 continue
             # nothing matched; use raw item value
             util.LOG('Filter value not listed, using raw item value: {0}'.format(item))
@@ -376,6 +378,7 @@ class Playlist(playlist.BasePlaylist, signalsmixin.SignalsMixin):
 
     def __init__(self, *args, **kwargs):
         playlist.BasePlaylist.__init__(self, *args, **kwargs)
+        signalsmixin.SignalsMixin.__init__(self)
         self._itemsLoaded = False
 
     def __repr__(self):
@@ -426,7 +429,7 @@ class Playlist(playlist.BasePlaylist, signalsmixin.SignalsMixin):
 
     def unshuffledItems(self):
         if not self._itemsLoaded:
-            self.items()
+            list(self.items())
         return self._items
 
     @property
@@ -483,7 +486,7 @@ class Hub(BaseHub):
         """ Reload the data for this object from PlexServer XML. """
         try:
             data = self.server.query(self.key, params=kwargs)
-        except Exception, e:
+        except Exception as e:
             import traceback
             traceback.print_exc()
             util.ERROR(err=e)

--- a/lib/_included_packages/plexnet/plexmedia.py
+++ b/lib/_included_packages/plexnet/plexmedia.py
@@ -1,9 +1,12 @@
-import locks
-import http
-import plexobjects
-import plexpart
-import plexrequest
-import util
+from __future__ import absolute_import
+from . import locks
+from . import http
+from . import plexobjects
+from . import plexpart
+from . import plexrequest
+from . import util
+from six.moves import filter
+import six
 
 
 class PlexMedia(plexobjects.PlexObject):
@@ -118,7 +121,7 @@ class PlexMedia(plexobjects.PlexObject):
             details.append(util.bitrateToString(self.bitrate.asInt() * 1000))
 
         detailString = ', '.join(details)
-        return (log_safe and ' * ' or u" \u2022 ").join(filter(None, [self.title, detailString]))
+        return (log_safe and ' * ' or u" \u2022 ").join([_f for _f in [self.title, detailString] if _f])
 
     def __eq__(self, other):
         if not other:
@@ -138,7 +141,7 @@ class PlexMedia(plexobjects.PlexObject):
     def getVideoResolution(self):
         if self.videoResolution:
             standardDefinitionHeight = 480
-            if str(util.validInt(filter(unicode.isdigit, self.videoResolution))) != self.videoResolution:
+            if str(util.validInt(list(filter(six.text_type.isdigit, self.videoResolution)))) != self.videoResolution:
                 return self.height.asInt() > standardDefinitionHeight and self.height.asInt() or standardDefinitionHeight
             else:
                 return self.videoResolution.asInt(standardDefinitionHeight)
@@ -146,14 +149,14 @@ class PlexMedia(plexobjects.PlexObject):
         return self.height.asInt()
 
     def getVideoResolutionString(self):
-        resNumber = util.validInt(filter(unicode.isdigit, self.videoResolution))
+        resNumber = util.validInt(list(filter(six.text_type.isdigit, self.videoResolution)))
         if resNumber > 0 and str(resNumber) == self.videoResolution:
             return self.videoResolution + "p"
 
         return self.videoResolution.upper()
 
     def isSelected(self):
-        import plexapp
-        return self.selected.asBool() or self.id == plexapp.INTERFACE.getPreference("local_mediaId")
+        from . import plexapp
+        return self.selected.asBool() or self.id == util.INTERFACE.getPreference("local_mediaId")
 
     # TODO(schuyler): getParts

--- a/lib/_included_packages/plexnet/plexobjects.py
+++ b/lib/_included_packages/plexnet/plexobjects.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 from datetime import datetime
 
-import exceptions
-import util
-import plexapp
+from . import exceptions
+from . import util
 import json
+import six
 
 # Search Types - Plex uses these to filter specific media types when searching.
 SEARCHTYPES = {
@@ -31,7 +32,7 @@ def registerLibFactory(ftype):
     return wrap
 
 
-class PlexValue(unicode):
+class PlexValue(six.text_type):
     def __new__(cls, value, parent=None):
         self = super(PlexValue, cls).__new__(cls, value)
         self.parent = parent
@@ -88,7 +89,7 @@ def asFullObject(func):
     return wrap
 
 
-class Checks:
+class Checks(object):
     def isLibraryItem(self):
         return "/library/metadata" in self.get('key', '') or ("/playlists/" in self.get('key', '') and self.get("type", "") == "playlist")
 
@@ -136,7 +137,7 @@ class Checks:
         return False
 
 
-class PlexObject(object, Checks):
+class PlexObject(Checks):
     def __init__(self, data, initpath=None, server=None, container=None):
         self.initpath = initpath
         self.key = None
@@ -182,7 +183,7 @@ class PlexObject(object, Checks):
         return ret is not None and ret or PlexValue(default, self)
 
     def set(self, attr, value):
-        setattr(self, attr, PlexValue(unicode(value), self))
+        setattr(self, attr, PlexValue(six.text_type(value), self))
 
     def init(self, data):
         pass
@@ -220,7 +221,7 @@ class PlexObject(object, Checks):
             else:
                 data = self.server.query(self.key, params=kwargs)
             self._reloaded = True
-        except Exception, e:
+        except Exception as e:
             import traceback
             traceback.print_exc()
             util.ERROR(err=e)
@@ -346,7 +347,8 @@ class PlexObject(object, Checks):
         server = self.server
 
         # If the server is myPlex, try to use a different PMS for transcoding
-        import myplexserver
+        from . import myplexserver
+        from . import plexapp
         if server == myplexserver.MyPlexServer:
             fallbackServer = plexapp.SERVERMANAGER.getChannelServer()
 
@@ -359,7 +361,7 @@ class PlexObject(object, Checks):
 
     @classmethod
     def deSerialize(cls, jstring):
-        import plexserver
+        from . import plexserver
         obj = json.loads(jstring)
         server = plexserver.PlexServer.deSerialize(obj['server'])
         server.identifier = None
@@ -414,7 +416,7 @@ class PlexContainer(PlexObject):
 class PlexServerContainer(PlexContainer):
     def __init__(self, data, initpath=None, server=None, address=None):
         PlexContainer.__init__(self, data, initpath, server, address)
-        import plexserver
+        from . import plexserver
         self.resources = [plexserver.PlexServer(elem) for elem in data]
 
     def __getitem__(self, idx):

--- a/lib/_included_packages/plexnet/plexpart.py
+++ b/lib/_included_packages/plexnet/plexpart.py
@@ -1,7 +1,8 @@
-import plexobjects
-import plexstream
-import plexrequest
-import util
+from __future__ import absolute_import
+from . import plexobjects
+from . import plexstream
+from . import plexrequest
+from . import util
 
 
 class PlexPart(plexobjects.PlexObject):
@@ -100,7 +101,7 @@ class PlexPart(plexobjects.PlexObject):
 
         return default
 
-    def setSelectedStream(self, streamType, streamId, async):
+    def setSelectedStream(self, streamType, streamId, _async):
         if streamType == plexstream.PlexStream.TYPE_AUDIO:
             typeString = "audio"
         elif streamType == plexstream.PlexStream.TYPE_SUBTITLE:
@@ -117,10 +118,10 @@ class PlexPart(plexobjects.PlexObject):
 
         request = plexrequest.PlexRequest(self.getServer(), path, "PUT")
 
-        if async:
+        if _async:
             context = request.createRequestContext("ignored")
-            import plexapp
-            plexapp.APP.startRequest(request, context, "")
+            from . import plexapp
+            util.APP.startRequest(request, context, "")
         else:
             request.postToStringWithTimeout()
 

--- a/lib/_included_packages/plexnet/plexplayer.py
+++ b/lib/_included_packages/plexnet/plexplayer.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
 import re
-import util
-import captions
-import http
-import plexrequest
-import mediadecisionengine
-import serverdecision
+from . import util
+from . import captions
+from . import http
+from . import plexrequest
+from . import mediadecisionengine
+from . import serverdecision
+from six.moves import range
 
 DecisionFailure = serverdecision.DecisionFailure
 

--- a/lib/_included_packages/plexnet/plexrequest.py
+++ b/lib/_included_packages/plexnet/plexrequest.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 from xml.etree import ElementTree
 
-import plexserver
-import plexresult
-import http
-import util
+from . import plexserver
+from . import plexresult
+from . import http
+from . import util
 
 
 class PlexRequest(http.HttpRequest):

--- a/lib/_included_packages/plexnet/plexresource.py
+++ b/lib/_included_packages/plexnet/plexresource.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import
 from xml.etree import ElementTree
 
-import http
-import exceptions
-import plexobjects
-import plexconnection
-import util
+from . import http
+from . import exceptions
+from . import plexobjects
+from . import plexconnection
+from . import util
 
 RESOURCES = 'https://plex.tv/api/resources?includeHttps=1'
 
@@ -174,7 +175,7 @@ def fetchResources(token):
     util.LOG('GET {0}?X-Plex-Token={1}'.format(RESOURCES, util.hideToken(token)))
     response = http.GET(RESOURCES)
     data = ElementTree.fromstring(response.text.encode('utf8'))
-    import plexserver
+    from . import plexserver
     return [plexserver.PlexServer(elem) for elem in data]
 
 

--- a/lib/_included_packages/plexnet/plexresult.py
+++ b/lib/_included_packages/plexnet/plexresult.py
@@ -1,5 +1,6 @@
-import http
-import plexobjects
+from __future__ import absolute_import
+from . import http
+from . import plexobjects
 
 
 class PlexResult(http.HttpResponse):

--- a/lib/_included_packages/plexnet/plexserver.py
+++ b/lib/_included_packages/plexnet/plexserver.py
@@ -1,20 +1,21 @@
 # -*- coding: utf-8 -*-
-import http
+from __future__ import absolute_import
+from . import http
 import time
-import util
-import exceptions
-import compat
-import verlib
+from . import util
+from . import exceptions
+from . import compat
+from . import verlib
 import re
 import json
 from xml.etree import ElementTree
 
-import signalsmixin
-import plexobjects
-import plexresource
-import plexlibrary
-import plexapp
-import asyncadapter
+from . import signalsmixin
+from . import plexobjects
+from . import plexresource
+from . import plexlibrary
+from . import asyncadapter
+from six.moves import range
 # from plexapi.client import Client
 # from plexapi.playqueue import PlayQueue
 
@@ -172,7 +173,7 @@ class PlexServer(plexresource.PlexResource, signalsmixin.SignalsMixin):
         # If URL is empty, try refresh resources and return empty set for now
         if not url:
             util.WARN_LOG("Empty server url, returning None and refreshing resources")
-            plexapp.MANAGER.refreshResources(True)
+            util.MANAGER.refreshResources(True)
             return None
 
         util.LOG('{0} {1}'.format(method.__name__.upper(), re.sub('X-Plex-Token=[^&]+', 'X-Plex-Token=****', url)))
@@ -184,7 +185,7 @@ class PlexServer(plexresource.PlexResource, signalsmixin.SignalsMixin):
             data = response.text.encode('utf8')
         except asyncadapter.TimeoutException:
             util.ERROR()
-            plexapp.MANAGER.refreshResources(True)
+            util.MANAGER.refreshResources(True)
             return None
         except http.requests.ConnectionError:
             util.ERROR()
@@ -207,7 +208,7 @@ class PlexServer(plexresource.PlexResource, signalsmixin.SignalsMixin):
 
         # Try to use a better server to transcode for synced servers
         if self.synced:
-            import plexservermanager
+            from . import plexservermanager
             selectedServer = plexservermanager.MANAGER.getTranscodeServer("photo")
             if selectedServer:
                 return selectedServer.buildUrl(path, True)
@@ -296,7 +297,7 @@ class PlexServer(plexresource.PlexResource, signalsmixin.SignalsMixin):
             if util.normalizedVersion(v) <= self.versionNorm:
                 self.features[f] = True
 
-        appMinVer = plexapp.INTERFACE.getGlobal('minServerVersionArr', '0.0.0.0')
+        appMinVer = util.INTERFACE.getGlobal('minServerVersionArr', '0.0.0.0')
         self.isSupported = self.isSecondary() or util.normalizedVersion(appMinVer) <= self.versionNorm
 
         util.DEBUG_LOG("Server information updated from reachability check: {0}".format(self))
@@ -376,7 +377,7 @@ class PlexServer(plexresource.PlexResource, signalsmixin.SignalsMixin):
 
         util.LOG("Active connection for {0} is {1}".format(repr(self.name), self.activeConnection))
 
-        import plexservermanager
+        from . import plexservermanager
         plexservermanager.MANAGER.updateReachabilityResult(self, bool(self.activeConnection))
 
     def markAsRefreshing(self):
@@ -481,7 +482,7 @@ class PlexServer(plexresource.PlexResource, signalsmixin.SignalsMixin):
         self.librariesByUuid[uuid] = library
 
     def hasInsecureConnections(self):
-        if plexapp.INTERFACE.getPreference('allow_insecure') == 'always':
+        if util.INTERFACE.getPreference('allow_insecure') == 'always':
             return False
 
         # True if we have any insecure connections we have disallowed
@@ -544,7 +545,7 @@ class PlexServer(plexresource.PlexResource, signalsmixin.SignalsMixin):
             util.ERROR_LOG("Failed to deserialize PlexServer JSON")
             return
 
-        import plexconnection
+        from . import plexconnection
 
         server = createPlexServerForName(serverObj['uuid'], serverObj['name'])
         server.owned = bool(serverObj.get('owned'))

--- a/lib/_included_packages/plexnet/plexservermanager.py
+++ b/lib/_included_packages/plexnet/plexservermanager.py
@@ -5,7 +5,6 @@ from . import http
 from . import plexconnection
 from . import plexresource
 from . import plexserver
-from . import myplexserver
 from . import signalsmixin
 from . import callback
 from . import plexapp
@@ -74,6 +73,7 @@ class PlexServerManager(signalsmixin.SignalsMixin):
         if uuid is None:
             return None
         elif uuid == "myplex":
+            from . import myplexserver
             return myplexserver.MyPlexServer()
         else:
             return self.serversByUuid[uuid]

--- a/lib/_included_packages/plexnet/plexservermanager.py
+++ b/lib/_included_packages/plexnet/plexservermanager.py
@@ -1,15 +1,17 @@
+from __future__ import absolute_import
 import json
 
-import http
-import plexconnection
-import plexresource
-import plexserver
-import myplexserver
-import signalsmixin
-import callback
-import plexapp
-import gdm
-import util
+from . import http
+from . import plexconnection
+from . import plexresource
+from . import plexserver
+from . import myplexserver
+from . import signalsmixin
+from . import callback
+from . import plexapp
+from . import gdm
+from . import util
+from six.moves import range
 
 
 class SearchContext(dict):
@@ -33,9 +35,9 @@ class PlexServerManager(signalsmixin.SignalsMixin):
         self.startSelectedServerSearch()
         self.loadState()
 
-        plexapp.APP.on("change:user", callback.Callable(self.onAccountChange))
-        plexapp.APP.on("change:allow_insecure", callback.Callable(self.onSecurityChange))
-        plexapp.APP.on("change:manual_connections", callback.Callable(self.onManualConnectionChange))
+        plexapp.util.APP.on("change:user", callback.Callable(self.onAccountChange))
+        plexapp.util.APP.on("change:allow_insecure", callback.Callable(self.onSecurityChange))
+        plexapp.util.APP.on("change:manual_connections", callback.Callable(self.onManualConnectionChange))
 
     def getSelectedServer(self):
         return self.selectedServer
@@ -62,7 +64,7 @@ class PlexServerManager(signalsmixin.SignalsMixin):
             self.saveState()
 
             # Notify anyone who might care.
-            plexapp.APP.trigger("change:selectedServer", server=server)
+            util.APP.trigger("change:selectedServer", server=server)
 
             return True
 
@@ -304,7 +306,7 @@ class PlexServerManager(signalsmixin.SignalsMixin):
             return 0
 
     def loadState(self):
-        jstring = plexapp.INTERFACE.getRegistry("PlexServerManager")
+        jstring = util.INTERFACE.getRegistry("PlexServerManager")
         if not jstring:
             return
 
@@ -381,12 +383,12 @@ class PlexServerManager(signalsmixin.SignalsMixin):
                 obj['servers'].append(serverObj)
 
         if self.selectedServer and not self.selectedServer.synced and not self.selectedServer.isSecondary():
-            plexapp.INTERFACE.setPreference("lastServerId", self.selectedServer.uuid)
+            util.INTERFACE.setPreference("lastServerId", self.selectedServer.uuid)
 
-        plexapp.INTERFACE.setRegistry("PlexServerManager", json.dumps(obj))
+        util.INTERFACE.setRegistry("PlexServerManager", json.dumps(obj))
 
     def clearState(self):
-        plexapp.INTERFACE.setRegistry("PlexServerManager", '')
+        util.INTERFACE.setRegistry("PlexServerManager", '')
 
     def isValidForTranscoding(self, server):
         return server and server.activeConnection and server.owned and not server.synced and not server.isSecondary()
@@ -449,7 +451,7 @@ class PlexServerManager(signalsmixin.SignalsMixin):
         # Keep track of some information during our search
         self.searchContext = SearchContext({
             'bestServer': None,
-            'preferredServer': plexapp.INTERFACE.getPreference('lastServerId', ''),
+            'preferredServer': util.INTERFACE.getPreference('lastServerId', ''),
             'waitingForResources': plexapp.ACCOUNT.isSignedIn
         })
 
@@ -491,7 +493,7 @@ class PlexServerManager(signalsmixin.SignalsMixin):
     def deferUpdateReachability(self, addTimer=True, logInfo=True):
         if addTimer and not self.deferReachabilityTimer:
             self.deferReachabilityTimer = plexapp.createTimer(1000, callback.Callable(self.onDeferUpdateReachabilityTimer), repeat=True)
-            plexapp.APP.addTimer(self.deferReachabilityTimer)
+            util.APP.addTimer(self.deferReachabilityTimer)
         else:
             if self.deferReachabilityTimer:
                 self.deferReachabilityTimer.reset()
@@ -574,7 +576,7 @@ class PlexServerManager(signalsmixin.SignalsMixin):
             context.address = conn.connection
             context.proto = proto
             context.port = port
-            plexapp.APP.startRequest(request, context)
+            util.APP.startRequest(request, context)
 
     def onManualConnectionsResponse(self, request, response, context):
         if not response.isSuccess():
@@ -601,7 +603,7 @@ class PlexServerManager(signalsmixin.SignalsMixin):
     def getManualConnections(self):
         manualConnections = []
 
-        jstring = plexapp.INTERFACE.getPreference('manual_connections')
+        jstring = util.INTERFACE.getPreference('manual_connections')
         if jstring:
             connections = json.loads(jstring)
             if isinstance(connections, list):

--- a/lib/_included_packages/plexnet/plexstream.py
+++ b/lib/_included_packages/plexnet/plexstream.py
@@ -1,5 +1,6 @@
-import plexobjects
-import util
+from __future__ import absolute_import
+from . import plexobjects
+from . import util
 
 
 class PlexStream(plexobjects.PlexObject):

--- a/lib/_included_packages/plexnet/serverdecision.py
+++ b/lib/_included_packages/plexnet/serverdecision.py
@@ -1,5 +1,6 @@
-import mediachoice
-import util
+from __future__ import absolute_import
+from . import mediachoice
+from . import util
 
 
 class DecisionFailure(Exception):

--- a/lib/_included_packages/plexnet/signalslot/__init__.py
+++ b/lib/_included_packages/plexnet/signalslot/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 try:
     from .signal import Signal
     from .slot import Slot

--- a/lib/_included_packages/plexnet/signalslot/contrib/task/task.py
+++ b/lib/_included_packages/plexnet/signalslot/contrib/task/task.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import sys
 import eventlet
 import contexter

--- a/lib/_included_packages/plexnet/signalslot/contrib/task/test.py
+++ b/lib/_included_packages/plexnet/signalslot/contrib/task/test.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import pytest
 import mock
 import logging

--- a/lib/_included_packages/plexnet/signalslot/signal.py
+++ b/lib/_included_packages/plexnet/signalslot/signal.py
@@ -2,6 +2,7 @@
 Module defining the Signal class.
 """
 
+from __future__ import absolute_import
 import inspect
 import threading
 

--- a/lib/_included_packages/plexnet/signalslot/slot.py
+++ b/lib/_included_packages/plexnet/signalslot/slot.py
@@ -2,6 +2,7 @@
 Module defining the Slot class.
 """
 
+from __future__ import absolute_import
 import types
 import weakref
 import sys

--- a/lib/_included_packages/plexnet/signalslot/tests.py
+++ b/lib/_included_packages/plexnet/signalslot/tests.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import pytest
 import mock
 

--- a/lib/_included_packages/plexnet/signalsmixin.py
+++ b/lib/_included_packages/plexnet/signalsmixin.py
@@ -3,6 +3,8 @@ from . import signalslot
 
 
 class SignalsMixin(object):
+    _signals = {}
+
     def __init__(self):
         self._signals = {}
 

--- a/lib/_included_packages/plexnet/signalsmixin.py
+++ b/lib/_included_packages/plexnet/signalsmixin.py
@@ -1,4 +1,5 @@
-import signalslot
+from __future__ import absolute_import
+from . import signalslot
 
 
 class SignalsMixin(object):

--- a/lib/_included_packages/plexnet/signalsmixin.py
+++ b/lib/_included_packages/plexnet/signalsmixin.py
@@ -3,8 +3,6 @@ from . import signalslot
 
 
 class SignalsMixin(object):
-    _signals = {}
-
     def __init__(self):
         self._signals = {}
 

--- a/lib/_included_packages/plexnet/simpleobjects.py
+++ b/lib/_included_packages/plexnet/simpleobjects.py
@@ -5,7 +5,7 @@ class Res(tuple):
     @classmethod
     def fromString(cls, res_string):
         try:
-            return cls(map(lambda n: int(n), res_string.split('x')))
+            return cls([int(n) for n in res_string.split('x')])
         except:
             return None
 

--- a/lib/_included_packages/plexnet/threadutils.py
+++ b/lib/_included_packages/plexnet/threadutils.py
@@ -1,5 +1,6 @@
 # import inspect
 # import ctypes
+from __future__ import absolute_import
 import threading
 # import time
 

--- a/lib/_included_packages/plexnet/util.py
+++ b/lib/_included_packages/plexnet/util.py
@@ -12,9 +12,9 @@ from . import verlib
 from . import compat
 
 if six.PY2:
-    _Event = threading._Event
+    Event = threading._Event
 else:
-    _Event = threading.Event
+    Event = threading.Event
 
 BASE_HEADERS = ''
 
@@ -208,9 +208,9 @@ def normalizedVersion(ver):
         return verlib.NormalizedVersion(verlib.suggest_normalized_version('0.0.0'))
 
 
-class CompatEvent(_Event):
+class CompatEvent(Event):
     def wait(self, timeout):
-        _Event.wait(self, timeout)
+        Event.wait(self, timeout)
         return self.isSet()
 
 

--- a/lib/_included_packages/plexnet/verlib.py
+++ b/lib/_included_packages/plexnet/verlib.py
@@ -2,6 +2,7 @@
 "Rational" version definition and parsing for DistutilsVersionFight
 discussion at PyCon 2009.
 """
+from __future__ import absolute_import
 import re
 
 

--- a/lib/_included_packages/plexnet/video.py
+++ b/lib/_included_packages/plexnet/video.py
@@ -1,11 +1,12 @@
-import plexobjects
-import media
-import plexmedia
-import plexstream
-import exceptions
-import compat
-import plexlibrary
-import util
+from __future__ import absolute_import
+from . import plexobjects
+from . import media
+from . import plexmedia
+from . import plexstream
+from . import exceptions
+from . import compat
+from . import plexlibrary
+from . import util
 
 
 class PlexVideoItemList(plexobjects.PlexItemList):
@@ -43,7 +44,7 @@ class Video(media.MediaItem):
     @property
     def settings(self):
         if not self._settings:
-            import plexapp
+            from . import plexapp
             self._settings = plexapp.PlayerSettingsInterface()
 
         return self._settings
@@ -66,8 +67,8 @@ class Video(media.MediaItem):
                     return stream
         return None
 
-    def selectStream(self, stream, async=True):
-        self.mediaChoice.part.setSelectedStream(stream.streamType.asInt(), stream.id, async)
+    def selectStream(self, stream, _async=True):
+        self.mediaChoice.part.setSelectedStream(stream.streamType.asInt(), stream.id, _async)
 
     def isVideoItem(self):
         return True
@@ -124,7 +125,7 @@ class Video(media.MediaItem):
             'directStream': '1',
             'directPlay': '0',
             'X-Plex-Platform': params.get('platform', ''),
-            # 'X-Plex-Platform': params.get('platform', plexapp.INTERFACE.getGlobal('platform')),
+            # 'X-Plex-Platform': params.get('platform', util.INTERFACE.getGlobal('platform')),
             'maxVideoBitrate': max(mvb, 64) if mvb else None,
             'videoResolution': '{0}x{1}'.format(*vr) if vr else None
         }

--- a/lib/backgroundthread.py
+++ b/lib/backgroundthread.py
@@ -1,8 +1,10 @@
-import Queue
+from __future__ import absolute_import
+import six.moves.queue
 import heapq
-import xbmc
-import util
+from kodi_six import xbmc
+from . import util
 from plexnet import threadutils
+from six.moves import range
 
 
 class Tasks(list):
@@ -30,6 +32,12 @@ class Task:
     def __cmp__(self, other):
         return self._priority - other._priority
 
+    def __le__(self, other):
+        return self._priority < other._priority
+
+    def __gt__(self, other):
+        return self._priority > other._priority
+
     def start(self):
         BGThreader.addTask(self)
 
@@ -50,7 +58,7 @@ class Task:
         return not self.finished and not self._canceled
 
 
-class MutablePriorityQueue(Queue.PriorityQueue):
+class MutablePriorityQueue(six.moves.queue.PriorityQueue):
     def _get(self, heappop=heapq.heappop):
             self.queue.sort()
             return heappop(self.queue)
@@ -109,7 +117,7 @@ class BackgroundWorker:
                 self._runTask(self._task)
                 self._queue.task_done()
                 self._task = None
-        except Queue.Empty:
+        except six.moves.queue.Empty:
             util.DEBUG_LOG('BGThreader ({0}): Idle'.format(self.name))
 
     def shutdown(self):

--- a/lib/compat.py
+++ b/lib/compat.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import time
 import datetime
 

--- a/lib/image.py
+++ b/lib/image.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 from lib import util
 

--- a/lib/kodijsonrpc.py
+++ b/lib/kodijsonrpc.py
@@ -1,4 +1,5 @@
-import xbmc
+from __future__ import absolute_import
+from kodi_six import xbmc
 import json
 
 

--- a/lib/main.py
+++ b/lib/main.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import xbmc
 
 if xbmc.getInfoLabel('Window(10000).Property(script.plex.running)') == "1":
@@ -9,14 +10,14 @@ import gc
 import atexit
 import threading
 
-import plex
+from . import plex
 
 from plexnet import plexapp
 from plexnet import threadutils
-from windows import background, userselect, home, windowutils
-import player
-import backgroundthread
-import util
+from .windows import background, userselect, home, windowutils
+from . import player
+from . import backgroundthread
+from . import util
 
 
 BACKGROUND = None

--- a/lib/main.py
+++ b/lib/main.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-import xbmc
+from kodi_six import xbmc
 
 if xbmc.getInfoLabel('Window(10000).Property(script.plex.running)') == "1":
     command = 'XBMC.NotifyAll({0},{1},{2})'.format('script.plex', 'RESTORE', None)
@@ -9,6 +9,7 @@ if xbmc.getInfoLabel('Window(10000).Property(script.plex.running)') == "1":
 import gc
 import atexit
 import threading
+import six
 
 from . import plex
 
@@ -23,6 +24,12 @@ from . import util
 BACKGROUND = None
 
 
+if six.PY2:
+    _Timer = threading._Timer
+else:
+    _Timer = threading.Timer
+
+
 def waitForThreads():
     util.DEBUG_LOG('Main: Checking for any remaining threads')
     while len(threading.enumerate()) > 1:
@@ -30,7 +37,7 @@ def waitForThreads():
             if t != threading.currentThread():
                 if t.isAlive():
                     util.DEBUG_LOG('Main: Waiting on: {0}...'.format(t.name))
-                    if isinstance(t, threading._Timer):
+                    if isinstance(t, _Timer):
                         t.cancel()
 
                     try:
@@ -96,7 +103,7 @@ def _main():
                             util.DEBUG_LOG('Main: Waiting for selected server...')
                             try:
                                 for timeout, skip_preferred, skip_owned in ((10, True, False), (10, True, True)):
-                                    plex.CallbackEvent(plexapp.APP, 'change:selectedServer', timeout=timeout).wait()
+                                    plex.CallbackEvent(plexapp.util.APP, 'change:selectedServer', timeout=timeout).wait()
 
                                     selectedServer = plexapp.SERVERMANAGER.checkSelectedServerSearch(skip_preferred=skip_preferred, skip_owned=skip_owned)
                                     if selectedServer:
@@ -136,17 +143,17 @@ def _main():
         util.DEBUG_LOG('Main: SHUTTING DOWN...')
         background.setShutdown()
         player.shutdown()
-        plexapp.APP.preShutdown()
+        plexapp.util.APP.preShutdown()
         util.CRON.stop()
         backgroundthread.BGThreader.shutdown()
-        plexapp.APP.shutdown()
+        plexapp.util.APP.shutdown()
         waitForThreads()
         background.setBusy(False)
         background.setSplash(False)
 
         util.DEBUG_LOG('FINISHED')
 
-        from windows import kodigui
+        from .windows import kodigui
         kodigui.MONITOR = None
         util.shutdown()
 

--- a/lib/metadata.py
+++ b/lib/metadata.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 from plexnet import media
-from util import T
+from .util import T
 
 
 EXTRA_MAP = {

--- a/lib/player.py
+++ b/lib/player.py
@@ -636,6 +636,10 @@ class PlexPlayer(xbmc.Player, signalsmixin.SignalsMixin):
     STATE_PAUSED = "paused"
     STATE_BUFFERING = "buffering"
 
+    def __init__(self, *args, **kwargs):
+        xbmc.Player.__init__(self, *args, **kwargs)
+        signalsmixin.SignalsMixin.__init__(self)
+
     def init(self):
         self._closed = False
         self._nextItem = None

--- a/lib/plex.py
+++ b/lib/plex.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import sys
 import platform
 import uuid
@@ -5,14 +6,21 @@ import json
 import threading
 import time
 import requests
+import six
 
-import xbmc
+from kodi_six import xbmc
 
 from plexnet import plexapp, myplex
-import util
+from . import util
+from six.moves import range
+
+if six.PY2:
+    _Event = threading._Event
+else:
+    _Event = threading.Event
 
 
-class PlexTimer(plexapp.Timer):
+class PlexTimer(plexapp.util.Timer):
     def shouldAbort(self):
         return xbmc.abortRequested
 
@@ -21,7 +29,7 @@ def abortFlag():
     return util.MONITOR.abortRequested()
 
 
-plexapp.setTimer(PlexTimer)
+plexapp.util.setTimer(PlexTimer)
 plexapp.setAbortFlagFunction(abortFlag)
 
 maxVideoRes = plexapp.Res((3840, 2160))  # INTERFACE.globals["supports4k"] and plexapp.Res((3840, 2160)) or plexapp.Res((1920, 1080))
@@ -218,13 +226,13 @@ class PlexInterface(plexapp.AppInterface):
             return 360
 
 
-plexapp.setInterface(PlexInterface())
+plexapp.util.setInterface(PlexInterface())
 plexapp.setUserAgent(defaultUserAgent())
 
 
-class CallbackEvent(plexapp.CompatEvent):
+class CallbackEvent(plexapp.util.CompatEvent):
     def __init__(self, context, signal, timeout=15, *args, **kwargs):
-        threading._Event.__init__(self, *args, **kwargs)
+        _Event.__init__(self, *args, **kwargs)
         self.start = time.time()
         self.context = context
         self.signal = signal
@@ -241,10 +249,10 @@ class CallbackEvent(plexapp.CompatEvent):
         return '<{0}:{1}>'.format(self.__class__.__name__, self.signal)
 
     def set(self, **kwargs):
-        threading._Event.set(self)
+        _Event.set(self)
 
     def wait(self):
-        if not threading._Event.wait(self, self.timeout):
+        if not _Event.wait(self, self.timeout):
             util.DEBUG_LOG('{0}: TIMED-OUT'.format(self))
         self.close()
 
@@ -255,7 +263,7 @@ class CallbackEvent(plexapp.CompatEvent):
                 return True
 
             if timeout:
-                threading._Event.wait(self, timeout)
+                _Event.wait(self, timeout)
         finally:
             return self.isSet()
 
@@ -267,7 +275,7 @@ class CallbackEvent(plexapp.CompatEvent):
 def init():
     util.DEBUG_LOG('Initializing...')
 
-    with CallbackEvent(plexapp.APP, 'init'):
+    with CallbackEvent(plexapp.util.APP, 'init'):
         plexapp.init()
         util.DEBUG_LOG('Waiting for account initialization...')
 
@@ -282,7 +290,7 @@ def init():
                 util.DEBUG_LOG('FAILED TO AUTHORIZE')
                 return False
 
-            with CallbackEvent(plexapp.APP, 'account:response'):
+            with CallbackEvent(plexapp.util.APP, 'account:response'):
                 plexapp.ACCOUNT.validateToken(token)
                 util.DEBUG_LOG('Waiting for account initialization...')
 
@@ -320,7 +328,7 @@ def requirePlexPass():
 
 
 def authorize():
-    from windows import signin, background
+    from .windows import signin, background
 
     background.setSplash(False)
 

--- a/lib/plex.py
+++ b/lib/plex.py
@@ -10,14 +10,9 @@ import six
 
 from kodi_six import xbmc
 
-from plexnet import plexapp, myplex
+from plexnet import plexapp, myplex, util as plexnet_util
 from . import util
 from six.moves import range
-
-if six.PY2:
-    _Event = threading._Event
-else:
-    _Event = threading.Event
 
 
 class PlexTimer(plexapp.util.Timer):
@@ -232,7 +227,7 @@ plexapp.setUserAgent(defaultUserAgent())
 
 class CallbackEvent(plexapp.util.CompatEvent):
     def __init__(self, context, signal, timeout=15, *args, **kwargs):
-        _Event.__init__(self, *args, **kwargs)
+        plexnet_util.Event.__init__(self, *args, **kwargs)
         self.start = time.time()
         self.context = context
         self.signal = signal
@@ -249,10 +244,10 @@ class CallbackEvent(plexapp.util.CompatEvent):
         return '<{0}:{1}>'.format(self.__class__.__name__, self.signal)
 
     def set(self, **kwargs):
-        _Event.set(self)
+        plexnet_util.Event.set(self)
 
     def wait(self):
-        if not _Event.wait(self, self.timeout):
+        if not plexnet_util.Event.wait(self, self.timeout):
             util.DEBUG_LOG('{0}: TIMED-OUT'.format(self))
         self.close()
 
@@ -263,7 +258,7 @@ class CallbackEvent(plexapp.util.CompatEvent):
                 return True
 
             if timeout:
-                _Event.wait(self, timeout)
+                plexnet_util.Event.wait(self, timeout)
         finally:
             return self.isSet()
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import gc
 import sys
 import re
@@ -9,21 +10,22 @@ import math
 import time
 import datetime
 import contextlib
-import urllib
+import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 
-from kodijsonrpc import rpc
-import xbmc
-import xbmcgui
-import xbmcaddon
+from .kodijsonrpc import rpc
+from kodi_six import xbmc
+from kodi_six import xbmcgui
+from kodi_six import xbmcaddon
 
 from plexnet import signalsmixin
+import six
 
 DEBUG = True
 _SHUTDOWN = False
 
 ADDON = xbmcaddon.Addon()
 
-PROFILE = xbmc.translatePath(ADDON.getAddonInfo('profile')).decode('utf-8')
+PROFILE = xbmc.translatePath(ADDON.getAddonInfo('profile'))
 
 SETTINGS_LOCK = threading.Lock()
 
@@ -37,7 +39,7 @@ class UtilityMonitor(xbmc.Monitor, signalsmixin.SignalsMixin):
 
     def onNotification(self, sender, method, data):
         if sender == 'script.plex' and method.endswith('RESTORE'):
-            from windows import kodigui
+            from .windows import kodigui
             getAdvancedSettings()
             populateTimeFormat()
             xbmc.executebuiltin('ActivateWindow({0})'.format(kodigui.BaseFunctions.lastWinID))
@@ -119,8 +121,6 @@ def DEBUG_LOG(msg):
 
 
 def ERROR(txt='', hide_tb=False, notify=False):
-    if isinstance(txt, str):
-        txt = txt.decode("utf-8")
     short = str(sys.exc_info()[1])
     if hide_tb:
         xbmc.log('script.plex: ERROR: {0} - {1}'.format(txt, short), xbmc.LOGERROR)
@@ -182,7 +182,7 @@ def videoIsPlaying():
 
 
 def messageDialog(heading='Message', msg=''):
-    from windows import optionsdialog
+    from .windows import optionsdialog
     optionsdialog.show(heading, msg, 'OK')
 
 
@@ -516,7 +516,7 @@ def getTimeFormat():
     # Checking for %H%H or %I%I only would be the obvious way here to determine whether the hour should be padded,
     # but the formats returned for regional settings with padding only have %H in them. This seems like a Kodi bug.
     # Use a fallback.
-    currentTime = unicode(xbmc.getInfoLabel('System.Time'), encoding="utf-8")
+    currentTime = xbmc.getInfoLabel('System.Time')
     padHour = "%H%H" in origFmt or "%I%I" in origFmt or (currentTime[0] == "0" and currentTime[1] != ":")
     return fmt, padHour
 
@@ -562,7 +562,7 @@ def addURLParams(url, params):
             url += '&'
         else:
             url += '?'
-        url += urllib.urlencode(params)
+        url += six.moves.urllib.parse.urlencode(params)
         return url
 
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -286,7 +286,7 @@ def timeDisplay(ms):
     h = ms / 3600000
     m = (ms % 3600000) / 60000
     s = (ms % 60000) / 1000
-    return '{0:0>2}:{1:0>2}:{2:0>2}'.format(h, m, s)
+    return '{0:0>2}:{1:0>2}:{2:0>2}'.format(int(h), int(m), int(s))
 
 
 def simplifiedTimeDisplay(ms):

--- a/lib/util.py
+++ b/lib/util.py
@@ -34,6 +34,10 @@ KODI_VERSION_MAJOR, KODI_VERSION_MINOR = int(_splitver[0].split("-")[0]), int(_s
 
 
 class UtilityMonitor(xbmc.Monitor, signalsmixin.SignalsMixin):
+    def __init__(self, *args, **kwargs):
+        xbmc.Monitor.__init__(self, *args, **kwargs)
+        signalsmixin.SignalsMixin.__init__(self)
+
     def watchStatusChanged(self):
         self.trigger('changed.watchstatus')
 

--- a/lib/windows/__init__.py
+++ b/lib/windows/__init__.py
@@ -1,4 +1,5 @@
-import kodigui
+from __future__ import absolute_import
+from . import kodigui
 from lib import util
 
 kodigui.MONITOR = util.MONITOR

--- a/lib/windows/background.py
+++ b/lib/windows/background.py
@@ -1,4 +1,5 @@
-import kodigui
+from __future__ import absolute_import
+from . import kodigui
 from lib import util
 
 util.setGlobalProperty('background.busy', '')

--- a/lib/windows/busy.py
+++ b/lib/windows/busy.py
@@ -1,4 +1,5 @@
-import kodigui
+from __future__ import absolute_import
+from . import kodigui
 from lib import util
 
 

--- a/lib/windows/currentplaylist.py
+++ b/lib/windows/currentplaylist.py
@@ -1,11 +1,12 @@
-import xbmc
-import xbmcgui
-import kodigui
+from __future__ import absolute_import
+from kodi_six import xbmc
+from kodi_six import xbmcgui
+from . import kodigui
 
-import busy
-import windowutils
-import dropdown
-import opener
+from . import busy
+from . import windowutils
+from . import dropdown
+from . import opener
 
 from lib import util
 from lib import player

--- a/lib/windows/dropdown.py
+++ b/lib/windows/dropdown.py
@@ -1,4 +1,5 @@
-import kodigui
+from __future__ import absolute_import
+from . import kodigui
 
 from lib import util
 

--- a/lib/windows/episodes.py
+++ b/lib/windows/episodes.py
@@ -1,6 +1,7 @@
-import xbmc
-import xbmcgui
-import kodigui
+from __future__ import absolute_import
+from kodi_six import xbmc
+from kodi_six import xbmcgui
+from . import kodigui
 
 from lib import colors
 from lib import util
@@ -10,18 +11,19 @@ from lib import player
 
 from plexnet import plexapp, playlist, plexplayer
 
-import busy
-import videoplayer
-import dropdown
-import windowutils
-import opener
-import search
-import playersettings
-import info
-import optionsdialog
-import preplayutils
+from . import busy
+from . import videoplayer
+from . import dropdown
+from . import windowutils
+from . import opener
+from . import search
+from . import playersettings
+from . import info
+from . import optionsdialog
+from . import preplayutils
 
 from lib.util import T
+from six.moves import range
 
 
 class EpisodeReloadTask(backgroundthread.Task):
@@ -176,9 +178,9 @@ class EpisodesWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
                 self.setFocusId(self.lastFocusID)
 
             if action == xbmcgui.ACTION_LAST_PAGE and xbmc.getCondVisibility('ControlGroup(300).HasFocus(0)'):
-                self.next()
+                next(self)
             elif action == xbmcgui.ACTION_NEXT_ITEM:
-                self.next()
+                next(self)
             elif action == xbmcgui.ACTION_FIRST_PAGE and xbmc.getCondVisibility('ControlGroup(300).HasFocus(0)'):
                 self.prev()
             elif action == xbmcgui.ACTION_PREV_ITEM:

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 import time
 import threading
 import re
 
-import xbmc
-import xbmcgui
+from kodi_six import xbmc
+from kodi_six import xbmcgui
 
-import kodigui
+from . import kodigui
 from lib import util
 from lib import backgroundthread
 from lib import colors
@@ -14,14 +15,15 @@ from lib import player
 import plexnet
 from plexnet import plexapp
 
-import windowutils
-import playlists
-import busy
-import opener
-import search
-import optionsdialog
+from . import windowutils
+from . import playlists
+from . import busy
+from . import opener
+from . import search
+from . import optionsdialog
 
 from lib.util import T
+from six.moves import range
 
 
 HUBS_REFRESH_INTERVAL = 300  # 5 Minutes
@@ -402,8 +404,8 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         plexapp.SERVERMANAGER.on('remove:server', self.onRemoveServer)
         plexapp.SERVERMANAGER.on('reachable:server', self.onReachableServer)
 
-        plexapp.APP.on('change:selectedServer', self.onSelectedServerChange)
-        plexapp.APP.on('account:response', self.displayServerAndUser)
+        plexapp.util.APP.on('change:selectedServer', self.onSelectedServerChange)
+        plexapp.util.APP.on('account:response', self.displayServerAndUser)
 
         player.PLAYER.on('session.ended', self.updateOnDeckHubs)
         util.MONITOR.on('changed.watchstatus', self.updateOnDeckHubs)
@@ -413,8 +415,8 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         plexapp.SERVERMANAGER.off('remove:server', self.onRemoveServer)
         plexapp.SERVERMANAGER.off('reachable:server', self.onReachableServer)
 
-        plexapp.APP.off('change:selectedServer', self.onSelectedServerChange)
-        plexapp.APP.off('account:response', self.displayServerAndUser)
+        plexapp.util.APP.off('change:selectedServer', self.onSelectedServerChange)
+        plexapp.util.APP.off('account:response', self.displayServerAndUser)
 
         player.PLAYER.off('session.ended', self.updateOnDeckHubs)
         util.MONITOR.off('changed.watchstatus', self.updateOnDeckHubs)
@@ -609,7 +611,11 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
             return
 
         if not mli.dataSource.exists():
-            control.removeItem(mli.pos())
+            try:
+                control.removeItem(mli.pos())
+            except ValueError:
+                # fixme: why?
+                pass
 
         if not control.size():
             idx = self.hubFocusIndexes[hubControlID - 400]
@@ -1054,7 +1060,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
             control.replaceItems(items)
 
     def updateListItem(self, mli):
-        if not mli:  # May have become invalid
+        if not mli or not mli.dataSource:  # May have become invalid
             return
 
         obj = mli.dataSource
@@ -1190,7 +1196,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
         self.setFocusId(self.USER_BUTTON_ID)
 
         if option == 'settings':
-            import settings
+            from . import settings
             settings.openWindow()
         elif option == 'go_online':
             plexapp.ACCOUNT.refreshAccount()
@@ -1199,7 +1205,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
             self.doClose()
 
     def showAudioPlayer(self):
-        import musicplayer
+        from . import musicplayer
         self.processCommand(opener.handleOpen(musicplayer.MusicPlayerWindow))
 
     def finished(self):

--- a/lib/windows/info.py
+++ b/lib/windows/info.py
@@ -1,5 +1,6 @@
-import kodigui
-import windowutils
+from __future__ import absolute_import
+from . import kodigui
+from . import windowutils
 from lib import util
 
 

--- a/lib/windows/kodigui.py
+++ b/lib/windows/kodigui.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
-import xbmc
-import xbmcgui
+from __future__ import absolute_import
+from kodi_six import xbmc
+from kodi_six import xbmcgui
 import time
 import threading
 import traceback
+import six
+from six.moves import range
+from six.moves import zip
 
 MONITOR = None
 
@@ -227,6 +231,8 @@ class DummyDataSource(object):
     def __nonzero__(self):
         return False
 
+    __bool__ = __nonzero__
+
     def exists(self):
         return False
 
@@ -236,7 +242,8 @@ DUMMY_DATA_SOURCE = DummyDataSource()
 
 class ManagedListItem(object):
     def __init__(self, label='', label2='', iconImage='', thumbnailImage='', path='', data_source=None, properties=None):
-        self._listItem = xbmcgui.ListItem(label, label2, iconImage, thumbnailImage, path)
+        self._listItem = xbmcgui.ListItem(label, label2, path=path)
+        self._listItem.setArt({"thumb": thumbnailImage, "icon": iconImage})
         self.dataSource = data_source
         self.properties = {}
         self.label = label
@@ -285,8 +292,7 @@ class ManagedListItem(object):
         self.listItem.setProperty('__ID__', self._ID)
         self.listItem.setLabel(self.label)
         self.listItem.setLabel2(self.label2)
-        self.listItem.setIconImage(self.iconImage)
-        self.listItem.setThumbnailImage(self.thumbnailImage)
+        self.listItem.setArt({"thumb": self.thumbnailImage, "icon": self.iconImage})
         self.listItem.setPath(self.path)
         for k in self._manager._properties.keys():
             self.listItem.setProperty(k, self.properties.get(k) or '')
@@ -341,7 +347,7 @@ class ManagedListItem(object):
 
     def setIconImage(self, icon):
         self.iconImage = icon
-        return self.listItem.setIconImage(icon)
+        return self.listItem.setArt({"icon": self.iconImage})
 
     def setInfo(self, itype, infoLabels):
         return self.listItem.setInfo(itype, infoLabels)
@@ -376,7 +382,7 @@ class ManagedListItem(object):
 
     def setThumbnailImage(self, thumb):
         self.thumbnailImage = thumb
-        return self.listItem.setThumbnailImage(thumb)
+        return self.listItem.setArt({"thumb": self.thumbnailImage})
 
     def onDestroy(self):
         pass
@@ -622,7 +628,7 @@ class ManagedControlList(object):
     def getViewRange(self):
         viewPosition = self.getViewPosition()
         selected = self.getSelectedPosition()
-        return range(max(selected - viewPosition, 0), min(selected + (self._maxViewIndex - viewPosition) + 1, self.size() - 1))
+        return list(range(max(selected - viewPosition, 0), min(selected + (self._maxViewIndex - viewPosition) + 1, self.size() - 1)))
 
     def positionIsValid(self, pos):
         return 0 <= pos < self.size()
@@ -999,7 +1005,7 @@ class WindowProperty():
 
 class GlobalProperty():
     def __init__(self, prop, val='1', end=None):
-        import xbmcaddon
+        from kodi_six import xbmcaddon
         self._addonID = xbmcaddon.Addon().getAddonInfo('id')
         self.prop = prop
         self.val = val

--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -1,30 +1,33 @@
+from __future__ import absolute_import
 import os
 import random
-import urllib
+import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 import json
 import time
 import threading
 
-import xbmc
-import xbmcgui
-import kodigui
+from kodi_six import xbmc
+from kodi_six import xbmcgui
+from . import kodigui
 
 from lib import colors
 from lib import util
 from lib import backgroundthread
 
-import busy
-import subitems
-import preplay
-import search
+from . import busy
+from . import subitems
+from . import preplay
+from . import search
 import plexnet
-import dropdown
-import opener
-import windowutils
+from . import dropdown
+from . import opener
+from . import windowutils
 
 from plexnet import playqueue
 
 from lib.util import T
+import six
+from six.moves import range
 
 CHUNK_SIZE = 200
 # CHUNK_SIZE = 30
@@ -190,7 +193,7 @@ class PhotoPropertiesTask(backgroundthread.Task):
 
 class LibrarySettings(object):
     def __init__(self, section_or_server_id):
-        if isinstance(section_or_server_id, basestring):
+        if isinstance(section_or_server_id, six.string_types):
             self.serverID = section_or_server_id
             self.sectionID = None
         else:
@@ -1257,7 +1260,7 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
             util.DEBUG_LOG('Filter missing sub-filter data')
             return None
 
-        return (self.filter['type'], urllib.unquote_plus(self.filter['sub']['val']))
+        return (self.filter['type'], six.moves.urllib.parse.unquote_plus(self.filter['sub']['val']))
 
     def getSortOpts(self):
         if not self.sort:

--- a/lib/windows/musicplayer.py
+++ b/lib/windows/musicplayer.py
@@ -1,7 +1,8 @@
-import xbmc
-import kodigui
-import currentplaylist
-import opener
+from __future__ import absolute_import
+from kodi_six import xbmc
+from . import kodigui
+from . import currentplaylist
+from . import opener
 
 from lib import player
 from lib import util
@@ -148,6 +149,6 @@ class MusicPlayerWindow(currentplaylist.CurrentPlaylistWindow):
                     index = i
             player.PLAYER.playAlbum(self.album, startpos=index, fanart=fanart)
         elif self.playlist:
-            player.PLAYER.playAudioPlaylist(self.playlist, startpos=self.playlist.items().index(self.track), fanart=fanart)
+            player.PLAYER.playAudioPlaylist(self.playlist, startpos=list(self.playlist.items()).index(self.track), fanart=fanart)
         else:
             player.PLAYER.playAudio(self.track)

--- a/lib/windows/opener.py
+++ b/lib/windows/opener.py
@@ -1,23 +1,25 @@
-import busy
+from __future__ import absolute_import
+from . import busy
 
 from plexnet import playqueue, plexapp, plexlibrary
 from lib import util
+import six
 
 
 def open(obj, auto_play=False):
     if isinstance(obj, playqueue.PlayQueue):
         if busy.widthDialog(obj.waitForInitialization, None):
             if obj.type == 'audio':
-                import musicplayer
+                from . import musicplayer
                 return handleOpen(musicplayer.MusicPlayerWindow, track=obj.current(), playlist=obj)
             elif obj.type == 'photo':
-                import photos
+                from . import photos
                 return handleOpen(photos.PhotoWindow, play_queue=obj)
             else:
-                import videoplayer
+                from . import videoplayer
                 videoplayer.play(play_queue=obj)
                 return ''
-    elif isinstance(obj, basestring):
+    elif isinstance(obj, six.string_types):
         key = obj
         if not obj.startswith('/'):
             key = '/library/metadata/{0}'.format(obj)
@@ -43,7 +45,7 @@ def open(obj, auto_play=False):
     elif obj.TYPE in ('playlist'):
         return playlistClicked(obj)
     elif obj.TYPE in ('clip'):
-        import videoplayer
+        from . import videoplayer
         return videoplayer.play(video=obj)
     elif obj.TYPE in ('Genre'):
         return genreClicked(obj)
@@ -74,42 +76,42 @@ def handleOpen(winclass, **kwargs):
 
 
 def playableClicked(playable, auto_play=False):
-    import preplay
+    from . import preplay
     return handleOpen(preplay.PrePlayWindow, video=playable, auto_play=auto_play)
 
 
 def episodeClicked(episode, auto_play=False):
-    import episodes
+    from . import episodes
     return handleOpen(episodes.EpisodesWindow, episode=episode, auto_play=auto_play)
 
 
 def showClicked(show):
-    import subitems
+    from . import subitems
     return handleOpen(subitems.ShowWindow, media_item=show)
 
 
 def artistClicked(artist):
-    import subitems
+    from . import subitems
     return handleOpen(subitems.ArtistWindow, media_item=artist)
 
 
 def seasonClicked(season):
-    import episodes
+    from . import episodes
     return handleOpen(episodes.EpisodesWindow, season=season)
 
 
 def albumClicked(album):
-    import tracks
+    from . import tracks
     return handleOpen(tracks.AlbumWindow, album=album)
 
 
 def photoClicked(photo):
-    import photos
+    from . import photos
     return handleOpen(photos.PhotoWindow, photo=photo)
 
 
 def trackClicked(track):
-    import musicplayer
+    from . import musicplayer
     return handleOpen(musicplayer.MusicPlayerWindow, track=track)
 
 
@@ -118,12 +120,12 @@ def photoDirectoryClicked(photodirectory):
 
 
 def playlistClicked(pl):
-    import playlist
+    from . import playlist
     return handleOpen(playlist.PlaylistWindow, playlist=pl)
 
 
 def sectionClicked(section, filter_=None):
-    import library
+    from . import library
     library.ITEM_TYPE = section.TYPE
     key = section.key
     if not key.isdigit():

--- a/lib/windows/optionsdialog.py
+++ b/lib/windows/optionsdialog.py
@@ -1,4 +1,5 @@
-import kodigui
+from __future__ import absolute_import
+from . import kodigui
 
 from lib import util
 

--- a/lib/windows/photos.py
+++ b/lib/windows/photos.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 import threading
 import time
 import os
 
-import xbmcgui
+from kodi_six import xbmcgui
 
-import kodigui
-import busy
+from . import kodigui
+from . import busy
 
 from lib import util, colors
 from plexnet import plexapp, plexplayer, playqueue
@@ -74,7 +75,7 @@ class PhotoWindow(kodigui.BaseWindow):
                     self.prev()
             elif action == xbmcgui.ACTION_MOVE_RIGHT:
                 if not self.osdVisible() or self.getFocusId() == self.PQUEUE_LIST_OVERLAY_BUTTON_ID:
-                    self.next()
+                    next(self)
             elif action == xbmcgui.ACTION_MOVE_UP:
                 if self.osdVisible():
                     if self.getFocusId() == self.OVERLAY_BUTTON_ID:
@@ -97,7 +98,7 @@ class PhotoWindow(kodigui.BaseWindow):
             elif action == xbmcgui.ACTION_PREV_ITEM:
                 self.prev()
             elif action == xbmcgui.ACTION_NEXT_ITEM:
-                self.next()
+                next(self)
             elif action in (xbmcgui.ACTION_PREVIOUS_MENU, xbmcgui.ACTION_NAV_BACK):
                 if self.osdVisible():
                     self.hideOSD()
@@ -123,7 +124,7 @@ class PhotoWindow(kodigui.BaseWindow):
         if controlID == self.PREV_BUTTON_ID:
             self.prev()
         elif controlID == self.NEXT_BUTTON_ID:
-            self.next()
+            next(self)
         elif controlID == self.PLAY_PAUSE_BUTTON_ID:
             if self.isPlaying():
                 self.pause()
@@ -299,7 +300,7 @@ class PhotoWindow(kodigui.BaseWindow):
         while not util.MONITOR.waitForAbort(0.1) and self.slideshowRunning:
             if not self.slideshowNext or time.time() < self.slideshowNext:
                 continue
-            self.next()
+            next(self)
 
         util.DEBUG_LOG('Slideshow: STOPPED')
 
@@ -322,7 +323,7 @@ class PhotoWindow(kodigui.BaseWindow):
         self.showPhoto()
 
     def next(self):
-        if not self.playQueue.next():
+        if not next(self.playQueue):
             return
         self.updateProperties()
         self.showPhoto()
@@ -381,7 +382,7 @@ class PhotoWindow(kodigui.BaseWindow):
         if refreshQueue and self.playQueue:
             self.playQueue.refreshOnTimeline = True
 
-        plexapp.APP.nowplayingmanager.updatePlaybackState(self.timelineType, self.playerObject, state, time, self.playQueue)
+        plexapp.util.APP.nowplayingmanager.updatePlaybackState(self.timelineType, self.playerObject, state, time, self.playQueue)
 
     def showOSD(self):
         self.osdTimer.reset(init=False)

--- a/lib/windows/playerbackground.py
+++ b/lib/windows/playerbackground.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 import contextlib
-import kodigui
+from . import kodigui
 from lib import util
 
 

--- a/lib/windows/playersettings.py
+++ b/lib/windows/playersettings.py
@@ -1,5 +1,6 @@
-import xbmc
-import kodigui
+from __future__ import absolute_import
+from kodi_six import xbmc
+from . import kodigui
 
 from lib import util
 from lib import metadata

--- a/lib/windows/playlist.py
+++ b/lib/windows/playlist.py
@@ -1,16 +1,17 @@
+from __future__ import absolute_import
 import threading
 
-import xbmc
-import xbmcgui
-import kodigui
+from kodi_six import xbmc
+from kodi_six import xbmcgui
+from . import kodigui
 
-import busy
-import videoplayer
-import windowutils
-import dropdown
-import search
+from . import busy
+from . import videoplayer
+from . import windowutils
+from . import dropdown
+from . import search
 import plexnet
-import opener
+from . import opener
 
 from lib import colors
 from lib import util
@@ -18,6 +19,7 @@ from lib import player
 from lib import backgroundthread
 
 from lib.util import T
+from six.moves import range
 
 PLAYLIST_PAGE_SIZE = 500
 PLAYLIST_INITIAL_SIZE = 100

--- a/lib/windows/playlists.py
+++ b/lib/windows/playlists.py
@@ -1,11 +1,12 @@
-import xbmc
-import xbmcgui
-import kodigui
+from __future__ import absolute_import
+from kodi_six import xbmc
+from kodi_six import xbmcgui
+from . import kodigui
 
-import busy
-import playlist
-import windowutils
-import search
+from . import busy
+from . import playlist
+from . import windowutils
+from . import search
 
 from lib import util
 from lib import colors

--- a/lib/windows/preplay.py
+++ b/lib/windows/preplay.py
@@ -1,17 +1,18 @@
-import xbmc
-import xbmcgui
-import kodigui
+from __future__ import absolute_import
+from kodi_six import xbmc
+from kodi_six import xbmcgui
+from . import kodigui
 
-import busy
-import opener
-import info
-import videoplayer
-import playersettings
-import search
-import dropdown
-import windowutils
-import optionsdialog
-import preplayutils
+from . import busy
+from . import opener
+from . import info
+from . import videoplayer
+from . import playersettings
+from . import search
+from . import dropdown
+from . import windowutils
+from . import optionsdialog
+from . import preplayutils
 
 from plexnet import plexplayer, media
 
@@ -114,10 +115,10 @@ class PrePlayWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
                     return
 
             if action == xbmcgui.ACTION_LAST_PAGE and xbmc.getCondVisibility('ControlGroup(300).HasFocus(0)'):
-                self.next()
+                next(self)
             elif action == xbmcgui.ACTION_NEXT_ITEM:
                 self.setFocusId(300)
-                self.next()
+                next(self)
             elif action == xbmcgui.ACTION_FIRST_PAGE and xbmc.getCondVisibility('ControlGroup(300).HasFocus(0)'):
                 self.prev()
             elif action == xbmcgui.ACTION_PREV_ITEM:

--- a/lib/windows/preplayutils.py
+++ b/lib/windows/preplayutils.py
@@ -1,4 +1,5 @@
-import dropdown
+from __future__ import absolute_import
+from . import dropdown
 
 from lib.util import T
 

--- a/lib/windows/search.py
+++ b/lib/windows/search.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 import time
 import threading
 
-import xbmcgui
+from kodi_six import xbmcgui
 
-import kodigui
-import opener
-import windowutils
+from . import kodigui
+from . import opener
+from . import windowutils
 
 from lib import util
 from lib.kodijsonrpc import rpc

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -1,18 +1,20 @@
+from __future__ import absolute_import
 import re
 import time
 import threading
 
-import xbmc
-import xbmcgui
+from kodi_six import xbmc
+from kodi_six import xbmcgui
 
-import kodigui
-import playersettings
-import dropdown
+from . import kodigui
+from . import playersettings
+from . import dropdown
 
 from lib import util
 from lib.kodijsonrpc import builtin
 
 from lib.util import T
+from six.moves import range
 
 
 KEY_MOVE_SET = frozenset(
@@ -275,7 +277,7 @@ class SeekDialog(kodigui.BaseDialog):
             elif action.getButtonCode() == 61524:
                 builtin.Action('ShowSubtitles')
             elif action == xbmcgui.ACTION_NEXT_ITEM:
-                self.handler.next()
+                next(self.handler)
             elif action == xbmcgui.ACTION_PREV_ITEM:
                 self.handler.prev()
             elif action in (xbmcgui.ACTION_PREVIOUS_MENU, xbmcgui.ACTION_NAV_BACK, xbmcgui.ACTION_STOP):
@@ -371,7 +373,7 @@ class SeekDialog(kodigui.BaseDialog):
         elif controlID == self.PREV_BUTTON_ID:
             self.handler.prev()
         elif controlID == self.NEXT_BUTTON_ID:
-            self.handler.next()
+            next(self.handler)
         elif controlID == self.PLAYLIST_BUTTON_ID:
             self.showPlaylistDialog()
         elif controlID == self.OPTIONS_BUTTON_ID:

--- a/lib/windows/settings.py
+++ b/lib/windows/settings.py
@@ -1,7 +1,8 @@
-import xbmc
-import xbmcgui
-import kodigui
-import windowutils
+from __future__ import absolute_import
+from kodi_six import xbmc
+from kodi_six import xbmcgui
+from . import kodigui
+from . import windowutils
 
 from lib import util
 from lib.util import T
@@ -26,7 +27,7 @@ class Setting(object):
         old = self.get()
         if old != val:
             util.DEBUG_LOG('Setting: {0} - changed from [{1}] to [{2}]'.format(self.ID, old, val))
-            plexnet.plexapp.APP.trigger('change:{0}'.format(self.ID))
+            plexnet.util.APP.trigger('change:{0}'.format(self.ID))
         return util.setSetting(self.ID, val)
 
     def valueLabel(self):

--- a/lib/windows/signin.py
+++ b/lib/windows/signin.py
@@ -1,5 +1,6 @@
-import xbmcgui
-import kodigui
+from __future__ import absolute_import
+from kodi_six import xbmcgui
+from . import kodigui
 from lib import util
 
 

--- a/lib/windows/subitems.py
+++ b/lib/windows/subitems.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import gc
 
-import xbmc
-import xbmcgui
-import kodigui
+from kodi_six import xbmc
+from kodi_six import xbmcgui
+from . import kodigui
 
 from lib import colors
 from lib import util
@@ -10,16 +11,16 @@ from lib import metadata
 
 from plexnet import playlist
 
-import busy
-import episodes
-import tracks
-import opener
-import info
-import musicplayer
-import videoplayer
-import dropdown
-import windowutils
-import search
+from . import busy
+from . import episodes
+from . import tracks
+from . import opener
+from . import info
+from . import musicplayer
+from . import videoplayer
+from . import dropdown
+from . import windowutils
+from . import search
 
 from lib.util import T
 
@@ -186,10 +187,10 @@ class ShowWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
                         return
 
             if action == xbmcgui.ACTION_LAST_PAGE and xbmc.getCondVisibility('ControlGroup(300).HasFocus(0)'):
-                self.next()
+                next(self)
             elif action == xbmcgui.ACTION_NEXT_ITEM:
                 self.setFocusId(300)
-                self.next()
+                next(self)
             elif action == xbmcgui.ACTION_FIRST_PAGE and xbmc.getCondVisibility('ControlGroup(300).HasFocus(0)'):
                 self.prev()
             elif action == xbmcgui.ACTION_PREV_ITEM:

--- a/lib/windows/tracks.py
+++ b/lib/windows/tracks.py
@@ -1,18 +1,19 @@
-import xbmc
-import xbmcgui
-import kodigui
+from __future__ import absolute_import
+from kodi_six import xbmc
+from kodi_six import xbmcgui
+from . import kodigui
 
 from lib import colors
 from lib import util
 
 from plexnet import playlist
 
-import busy
-import musicplayer
-import dropdown
-import windowutils
-import opener
-import search
+from . import busy
+from . import musicplayer
+from . import dropdown
+from . import windowutils
+from . import opener
+from . import search
 
 from lib.util import T
 
@@ -63,9 +64,9 @@ class AlbumWindow(kodigui.ControlledWindow, windowutils.UtilMixin):
         controlID = self.getFocusId()
         try:
             if action == xbmcgui.ACTION_LAST_PAGE and xbmc.getCondVisibility('ControlGroup(300).HasFocus(0)'):
-                self.next()
+                next(self)
             elif action == xbmcgui.ACTION_NEXT_ITEM:
-                self.next()
+                next(self)
             elif action == xbmcgui.ACTION_FIRST_PAGE and xbmc.getCondVisibility('ControlGroup(300).HasFocus(0)'):
                 self.prev()
             elif action == xbmcgui.ACTION_PREV_ITEM:

--- a/lib/windows/userselect.py
+++ b/lib/windows/userselect.py
@@ -1,8 +1,9 @@
-import xbmc
-import xbmcgui
+from __future__ import absolute_import
+from kodi_six import xbmc
+from kodi_six import xbmcgui
 
-import kodigui
-import dropdown
+from . import kodigui
+from . import dropdown
 
 from lib import util, image, backgroundthread
 from plexnet import plexapp
@@ -188,7 +189,7 @@ class UserSelectWindow(kodigui.BaseWindow):
         util.DEBUG_LOG('Home user selected: {0}'.format(user))
 
         from lib import plex
-        with plex.CallbackEvent(plexapp.APP, 'account:response') as e:
+        with plex.CallbackEvent(plexapp.util.APP, 'account:response') as e:
             if plexapp.ACCOUNT.switchHomeUser(user.id, pin) and plexapp.ACCOUNT.switchUser:
                 util.DEBUG_LOG('Waiting for user change...')
             else:

--- a/lib/windows/videoplayer.py
+++ b/lib/windows/videoplayer.py
@@ -1,15 +1,16 @@
+from __future__ import absolute_import
 import time
 import threading
 
-import xbmc
-import xbmcgui
+from kodi_six import xbmc
+from kodi_six import xbmcgui
 
-import kodigui
-import windowutils
-import opener
-import busy
-import search
-import dropdown
+from . import kodigui
+from . import windowutils
+from . import opener
+from . import busy
+from . import search
+from . import dropdown
 
 from lib import util
 from lib import player

--- a/lib/windows/windowutils.py
+++ b/lib/windows/windowutils.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from lib import util
-import opener
-import dropdown
+from . import opener
+from . import dropdown
 
 from lib.util import T
 
@@ -35,7 +36,7 @@ class UtilMixin():
         self.doClose()
 
     def showAudioPlayer(self, **kwargs):
-        import musicplayer
+        from . import musicplayer
         self.processCommand(opener.handleOpen(musicplayer.MusicPlayerWindow, **kwargs))
 
     def getPlaylistResume(self, pl, items, title):

--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,7 @@
-import xbmc
-import xbmcplugin
-import xbmcgui
+from __future__ import absolute_import
+from kodi_six import xbmc
+from kodi_six import xbmcplugin
+from kodi_six import xbmcgui
 import sys
 import base64
 from lib import _included_packages, plex, util
@@ -25,7 +26,7 @@ def playTrack(track):
     url = apobj.build()['url']
     url = util.addURLParams(url, {
         'X-Plex-Client-Profile-Name': 'Chrome',
-        'X-Plex-Client-Identifier': plexapp.INTERFACE.getGlobal('clientIdentifier')
+        'X-Plex-Client-Identifier': plexapp.util.INTERFACE.getGlobal('clientIdentifier')
     })
     LOG('Playing URL: {0}'.format(url))
 

--- a/service.py
+++ b/service.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-import xbmc
-import xbmcgui
-import xbmcaddon
+from __future__ import absolute_import
+from kodi_six import xbmc
+from kodi_six import xbmcgui
+from kodi_six import xbmcaddon
 
 
 def main():


### PR DESCRIPTION
GHI (If applicable): #

## Description:
Kodi 19 drops Python 2 in favor of Python 3. This uses kodi.six and the six module, as well as a couple of compatibility changes in the code, to be backwards compatible with Kodi 18 and Python 3 compatible.

## Checklist:
- [x] I have based this PR against the develop branch
