### PR TITLE
ft(friendlyNameInConfig) add friendly name in Kodi config

### DIFF
--- a/lib/plex.py
+++ b/lib/plex.py
@@ -99,6 +99,9 @@ class PlexInterface(plexapp.AppInterface):
         ],
         'deviceInfo': plexapp.DeviceInfo()
     }
+    FRIENDLY_NAME = util.getSetting('friendly_name')      
+    if (FRIENDLY_NAME != ""):  
+        _globals['friendly_name'] = FRIENDLY_NAME
 
     def getPreference(self, pref, default=None):
         if pref == 'manual_connections':

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,6 +7,7 @@
 
     <!-- <setting id="playback_directplay_force" type="bool" label="32027" default="false" enable="eq(-1,true)" subsetting="true" /> -->
     <setting id="debug" type="bool" label="32024" default="false" />
+    <setting id="friendly_name" type="text" label="friendlyName" default="" />
   </category>
   <category label="32464">
     <setting id="auto_seek" type="bool" label="32466" default="true" />


### PR DESCRIPTION
GHI (If applicable): #

## Description:
Hello,
I add possibility to config of the player name in the config of kodi plugin.

Why did i do this ?
Because when I use the add-on with (Kodi) android on my Mi box I get this on tautulli.
<img width="197" alt="image" src="https://user-images.githubusercontent.com/6311124/69828757-74bb3980-121d-11ea-8403-fbd87adc3192.png">
I need a distinct name of player to catch on webhook for execute some stuff

Now with this feature, I can have this:
<img width="104" alt="image" src="https://user-images.githubusercontent.com/6311124/69829217-6c63fe00-121f-11ea-9443-b55bfd8a9d00.png">

Excuse me for my poor English

## Checklist:
- [x] I have based this PR against the develop branch
