### PR TITLE
Fix postplay hard crash

### DIFF
--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -1190,7 +1190,7 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
         if not mli:
             return
 
-        if not mli.dataSource.exists():
+        if mli.dataSource and not mli.dataSource.exists():
             self.showPanelControl.removeItem(mli.pos())
             return
 


### PR DESCRIPTION
GHI (If applicable): #

## Description:
`mli.dataSource` might be `None` after playing an unmatched item from a library resulting in a hard UI crash in postplay.

## Checklist:
- [x] I have based this PR against the develop branch
