### PR TITLE
Fix GDM - parsing of response field

### DIFF
--- a/lib/_included_packages/plexnet/gdm.py
+++ b/lib/_included_packages/plexnet/gdm.py
@@ -229,7 +229,7 @@ def parseFieldValue(message, label):
     if label not in message:
         return None
 
-    return message.split(label, 1)[-1].split(chr(13))[0]
+    return message.split(label, 1)[-1].split(chr(13).encode())[0].decode()
 
 
 DISCOVERY = GDMDiscovery()


### PR DESCRIPTION
GHI (If applicable): #

## Description:
Fix GDM response field parsing.
Second split by bytecode (.encode()), then result as string (.decode())
## Checklist:
- [x] I have based this PR against the develop branch
