### PR TITLE
Fix HTTPClient deprecated strict arg in PY3

### DIFF
--- a/lib/_included_packages/plexnet/asyncadapter.py
+++ b/lib/_included_packages/plexnet/asyncadapter.py
@@ -178,7 +178,8 @@ class AsyncHTTPConnectionPool(HTTPConnectionPool):
         self.num_connections += 1
 
         extra_params = {}
-        extra_params['strict'] = self.strict
+        if six.PY2:
+            extra_params['strict'] = self.strict
 
         conn = AsyncHTTPConnection(host=self.host, port=self.port, timeout=self.timeout.connect_timeout, **extra_params)
 
@@ -218,7 +219,8 @@ class AsyncHTTPSConnectionPool(HTTPSConnectionPool):
         connection_class = AsyncVerifiedHTTPSConnection
 
         extra_params = {}
-        extra_params['strict'] = self.strict
+        if six.PY2:
+            extra_params['strict'] = self.strict
         connection = connection_class(host=actual_host, port=actual_port, timeout=self.timeout.connect_timeout, **extra_params)
 
         self.connections.append(connection)


### PR DESCRIPTION
GHI (If applicable): #

## Description:
Fix URLLIB3 deprecated "strict" arg in Python3
## Checklist:
- [x] I have based this PR against the develop branch
