### PR TITLE
Fix deprecated calls to thread.isAlive() with thread.is_alive().

### DIFF
--- a/lib/_included_packages/plexnet/gdm.py
+++ b/lib/_included_packages/plexnet/gdm.py
@@ -26,7 +26,7 @@ class GDMDiscovery(object):
 
     def isActive(self):
         from . import plexapp
-        return util.INTERFACE.getPreference("gdm_discovery", True) and self.thread and self.thread.isAlive()
+        return util.INTERFACE.getPreference("gdm_discovery", True) and self.thread and self.thread.is_alive()
 
     '''
     def discover(self):

--- a/lib/_included_packages/plexnet/threadutils.py
+++ b/lib/_included_packages/plexnet/threadutils.py
@@ -41,7 +41,7 @@ class KillableThread(threading.Thread):
     #     thread, to get the identity of the thread represented by this
     #     instance.
     #     """
-    #     if not self.isAlive():
+    #     if not self.is_alive():
     #         raise threading.ThreadError("the thread is not active")
 
     #     return self.ident
@@ -58,7 +58,7 @@ class KillableThread(threading.Thread):
     #         t = ThreadWithExc( ... )
     #         ...
     #         t.raiseExc( SomeException )
-    #         while t.isAlive():
+    #         while t.is_alive():
     #             time.sleep( 0.1 )
     #             t.raiseExc( SomeException )
 
@@ -78,7 +78,7 @@ class KillableThread(threading.Thread):
 
     #         if force_and_wait:
     #             time.sleep(0.1)
-    #             while self.isAlive():
+    #             while self.is_alive():
     #                 self._raiseExc(KillThreadException)
     #                 time.sleep(0.1)
     #     except threading.ThreadError:

--- a/lib/_included_packages/plexnet/util.py
+++ b/lib/_included_packages/plexnet/util.py
@@ -256,7 +256,7 @@ class Timer(object):
     def reset(self):
         self._reset = True
         self.cancel()
-        if self.thread and self.thread.isAlive():
+        if self.thread and self.thread.is_alive():
             self.thread.join()
         self.start()
 
@@ -264,7 +264,7 @@ class Timer(object):
         return False
 
     def join(self):
-        if self.thread.isAlive():
+        if self.thread.is_alive():
             self.thread.join()
 
     def isExpired(self):

--- a/lib/backgroundthread.py
+++ b/lib/backgroundthread.py
@@ -100,7 +100,7 @@ class BackgroundWorker:
         return self._abort or util.MONITOR.abortRequested()
 
     def start(self):
-        if self._thread and self._thread.isAlive():
+        if self._thread and self._thread.is_alive():
             return
 
         self._thread = threadutils.KillableThread(target=self._queueLoop, name='BACKGROUND-WORKER({0})'.format(self.name))
@@ -126,13 +126,13 @@ class BackgroundWorker:
         if self._task:
             self._task.cancel()
 
-        if self._thread and self._thread.isAlive():
+        if self._thread and self._thread.is_alive():
             util.DEBUG_LOG('BGThreader: thread ({0}): Waiting...'.format(self.name))
             self._thread.join()
             util.DEBUG_LOG('BGThreader: thread ({0}): Done'.format(self.name))
 
     def working(self):
-        return self._thread and self._thread.isAlive()
+        return self._thread and self._thread.is_alive()
 
 
 class BackgroundThreader:

--- a/lib/main.py
+++ b/lib/main.py
@@ -35,7 +35,7 @@ def waitForThreads():
     while len(threading.enumerate()) > 1:
         for t in threading.enumerate():
             if t != threading.currentThread():
-                if t.isAlive():
+                if t.is_alive():
                     util.DEBUG_LOG('Main: Waiting on: {0}...'.format(t.name))
                     if isinstance(t, _Timer):
                         t.cancel()

--- a/lib/player.py
+++ b/lib/player.py
@@ -994,7 +994,7 @@ class PlexPlayer(xbmc.Player, signalsmixin.SignalsMixin):
             util.DEBUG_LOG('Player: Stopping and waiting...Done')
 
     def monitor(self):
-        if not self.thread or not self.thread.isAlive():
+        if not self.thread or not self.thread.is_alive():
             self.thread = threading.Thread(target=self._monitor, name='PLAYER:MONITOR')
             self.thread.start()
 

--- a/lib/windows/home.py
+++ b/lib/windows/home.py
@@ -693,7 +693,7 @@ class HomeWindow(kodigui.BaseWindow, util.CronReceiver):
 
     def sectionChanged(self, force=False):
         self.sectionChangeTimeout = time.time() + 0.3
-        if not self.sectionChangeThread or not self.sectionChangeThread.isAlive() or force:
+        if not self.sectionChangeThread or not self.sectionChangeThread.is_alive() or force:
             self.sectionChangeThread = threading.Thread(target=self._sectionChanged, name="sectionchanged")
             self.sectionChangeThread.start()
 

--- a/lib/windows/kodigui.py
+++ b/lib/windows/kodigui.py
@@ -942,7 +942,7 @@ class PropertyTimer():
         self._onTimeout()
 
     def _stopped(self):
-        return not self._thread or not self._thread.isAlive()
+        return not self._thread or not self._thread.is_alive()
 
     def _reset(self):
         self._endTime = time.time() + self._timeout

--- a/lib/windows/library.py
+++ b/lib/windows/library.py
@@ -768,7 +768,7 @@ class LibraryWindow(kodigui.MultiWindow, windowutils.UtilMixin):
             self.chunkCallback(None, None, clear=True)
         self.dcpjTimeout = time.time() + 0.5
         self.dcpjPos = pos
-        if not self.dcpjThread or not self.dcpjThread.isAlive():
+        if not self.dcpjThread or not self.dcpjThread.is_alive():
             self.dcpjThread = threading.Thread(target=self._chunkedPosJump)
             self.dcpjThread.start()
 

--- a/lib/windows/photos.py
+++ b/lib/windows/photos.py
@@ -225,7 +225,7 @@ class PhotoWindow(kodigui.BaseWindow):
         self.updatePqueueListSelection(photo)
 
         self.showPhotoTimeout = time.time() + 0.2
-        if not self.showPhotoThread or not self.showPhotoThread.isAlive():
+        if not self.showPhotoThread or not self.showPhotoThread.is_alive():
             self.showPhotoThread = threading.Thread(target=self._showPhoto, name="showphoto")
             self.showPhotoThread.start()
 
@@ -330,7 +330,7 @@ class PhotoWindow(kodigui.BaseWindow):
 
     def play(self):
         self.setProperty('playing', '1')
-        if self.slideshowThread and self.slideshowThread.isAlive():
+        if self.slideshowThread and self.slideshowThread.is_alive():
             return
 
         self.slideshowThread = threading.Thread(target=self.slideshow, name='slideshow')

--- a/lib/windows/search.py
+++ b/lib/windows/search.py
@@ -235,7 +235,7 @@ class SearchDialog(kodigui.BaseDialog, windowutils.UtilMixin):
 
     def updateResults(self):
         self.updateResultsTimeout = time.time() + 1
-        if not self.resultsThread or not self.resultsThread.isAlive():
+        if not self.resultsThread or not self.resultsThread.is_alive():
             self.resultsThread = threading.Thread(target=self._updateResults, name='search.update')
             self.resultsThread.start()
 

--- a/lib/windows/seekdialog.py
+++ b/lib/windows/seekdialog.py
@@ -516,7 +516,7 @@ class SeekDialog(kodigui.BaseDialog):
         self.setProperty('button.seek', '1')
         self._delayedSeekTimeout = time.time() + 1.0
 
-        if not self._delayedSeekThread or not self._delayedSeekThread.isAlive():
+        if not self._delayedSeekThread or not self._delayedSeekThread.is_alive():
             self._delayedSeekThread = threading.Thread(target=self._delayedSeek)
             self._delayedSeekThread.start()
 


### PR DESCRIPTION
This call was deprecated in python 3.9. See:
https://bugs.python.org/issue37804

GHI (If applicable): #349 

## Description:

Fixes #349.

This fix seems to work on 

Arch 5.11.7-arch1-1
Kodi 19.0
script.plex v0.3.3

I'm using Arch's `kodi-standalone` service and the `kodi-gbm` package.

## Checklist:
- [x] I have based this PR against the develop branch
