### PR TITLE
Multiple Kodi 19.1 fixes

### DIFF
--- a/lib/_included_packages/plexnet/http.py
+++ b/lib/_included_packages/plexnet/http.py
@@ -5,6 +5,7 @@ import re
 import traceback
 import requests
 import socket
+import urllib3
 from . import threadutils
 import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 import mimetypes

--- a/lib/_included_packages/plexnet/nowplayingmanager.py
+++ b/lib/_included_packages/plexnet/nowplayingmanager.py
@@ -190,9 +190,9 @@ class NowPlayingManager(object):
                 path = http.addUrlParam(path, paramKey + "=" + six.moves.urllib.parse.quote(str(params[paramKey])))
 
         request = plexrequest.PlexRequest(timeline.item.getServer(), path)
+
         context = request.createRequestContext("timelineUpdate", callback.Callable(self.onTimelineResponse))
         context.playQueue = timeline.playQueue
-        from . import plexapp
         util.APP.startRequest(request, context)
 
     def getServerTimeline(self, timelineType):

--- a/lib/player.py
+++ b/lib/player.py
@@ -752,6 +752,9 @@ class PlexPlayer(xbmc.Player, signalsmixin.SignalsMixin):
 
         meta = self.playerObject.metadata
 
+        # Kodi 19 will try to look for subtitles in the directory containing the file. '/' and `/file.mkv` both point
+        # to the file, and Kodi will happily try to read the whole file without recognizing it isn't a directory.
+        # To get around that, we omit the filename here since it is unnecessary.
         url = meta.streamUrls[0].replace("file.mkv", "")
 
         bifURL = self.playerObject.getBifUrl()

--- a/lib/player.py
+++ b/lib/player.py
@@ -752,7 +752,8 @@ class PlexPlayer(xbmc.Player, signalsmixin.SignalsMixin):
 
         meta = self.playerObject.metadata
 
-        url = meta.streamUrls[0]
+        url = meta.streamUrls[0].replace("file.mkv", "")
+
         bifURL = self.playerObject.getBifUrl()
         util.DEBUG_LOG('Playing URL(+{1}ms): {0}{2}'.format(plexnetUtil.cleanToken(url), offset, bifURL and ' - indexed' or ''))
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -16,6 +16,7 @@ from .kodijsonrpc import rpc
 from kodi_six import xbmc
 from kodi_six import xbmcgui
 from kodi_six import xbmcaddon
+from kodi_six import xbmcvfs
 
 from plexnet import signalsmixin
 import six
@@ -25,7 +26,7 @@ _SHUTDOWN = False
 
 ADDON = xbmcaddon.Addon()
 
-PROFILE = xbmc.translatePath(ADDON.getAddonInfo('profile'))
+PROFILE = xbmcvfs.translatePath(ADDON.getAddonInfo('profile'))
 
 SETTINGS_LOCK = threading.Lock()
 
@@ -176,7 +177,7 @@ def getGlobalProperty(key):
 
 def showNotification(message, time_ms=3000, icon_path=None, header=ADDON.getAddonInfo('name')):
     try:
-        icon_path = icon_path or xbmc.translatePath(ADDON.getAddonInfo('icon')).decode('utf-8')
+        icon_path = icon_path or xbmcvfs.translatePath(ADDON.getAddonInfo('icon'))
         xbmc.executebuiltin('Notification({0},{1},{2},{3})'.format(header, message, time_ms, icon_path))
     except RuntimeError:  # Happens when disabling the addon
         LOG(message)


### PR DESCRIPTION


GHI (If applicable): #347

## Description:
- fix missing import error
- unnecessary str decode error
- use xbmcvfs for translatepath (deprecated)
- fix playback with non-auth IPs enabled in PMS settings (#347)

## Checklist:
- [x] I have based this PR against the develop branch
