### PR TITLE
Fix B64 decode error at playlist creation

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -871,7 +871,7 @@ class PlexPlayer(xbmc.Player, signalsmixin.SignalsMixin):
         self.play(plist, startpos=startpos)
 
     def createTrackListItem(self, track, fanart=None, index=0):
-        data = base64.urlsafe_b64encode(track.serialize())
+        data = base64.urlsafe_b64encode(track.serialize().encode("utf8")).decode("utf8")
         url = 'plugin://script.plex/play?{0}'.format(data)
         li = xbmcgui.ListItem(track.title, path=url)
         li.setInfo('music', {


### PR DESCRIPTION
GHI (If applicable): #

## Description:

Error:
```
 Error Contents: a bytes-like object is required, not 'str'
 Traceback (most recent call last):
 File "/storage/.kodi/addons/script.plex/lib/windows/kodigui.py", line 105, in onInit
 self.onFirstInit()
 File "/storage/.kodi/addons/script.plex/lib/windows/musicplayer.py", line 64, in onFirstInit
 self.play()
 File "/storage/.kodi/addons/script.plex/lib/windows/musicplayer.py", line 152, in play
 player.PLAYER.playAudioPlaylist(self.playlist, startpos=list(self.playlist.items()).index(self.track), fanart=fanart)
 File "/storage/.kodi/addons/script.plex/lib/player.py", line 858, in playAudioPlaylist
 url, li = self.createTrackListItem(track, fanart, index=index)
 File "/storage/.kodi/addons/script.plex/lib/player.py", line 874, in createTrackListItem
 data = base64.urlsafe_b64encode(track.serialize())
 File "/usr/lib/python3.8/base64.py", line 118, in urlsafe_b64encode
 File "/usr/lib/python3.8/base64.py", line 58, in b64encode
 TypeError: a bytes-like object is required, not 'str'
```

## Checklist:
- [x] I have based this PR against the develop branch
