### PR TITLE
Allow all users to skip-intro if admin has plex pass

### DIFF
--- a/lib/_included_packages/plexnet/myplexaccount.py
+++ b/lib/_included_packages/plexnet/myplexaccount.py
@@ -220,7 +220,7 @@ class MyPlexAccount(object):
         self.saveState()
 
     def hasPlexPass(self):
-        return self.isPlexPass or (self.isManaged and self.adminHasPlexPass)
+        return self.isPlexPass or self.adminHasPlexPass
 
     def validateToken(self, token, switchUser=False):
         self.authToken = token


### PR DESCRIPTION
Signed-off-by: fvlaicu <19238716+fvlaicu@users.noreply.github.com>

GHI (If applicable): #

## Description:
the other plex clients allow all users to skip-intro if the admin has plexpass.
## Checklist:
- [x] I have based this PR against the develop branch
