### PR TITLE
Don't request collections with the library

### DIFF
--- a/lib/_included_packages/plexnet/plexlibrary.py
+++ b/lib/_included_packages/plexnet/plexlibrary.py
@@ -136,7 +136,7 @@ class LibrarySection(plexobjects.PlexObject):
         else:
             path = '/library/sections/{0}/all'.format(self.key)
 
-        args = {"includeCollections" : "1"}
+        args = {"includeCollections" : "0"}
 
         if size is not None:
             args['X-Plex-Container-Start'] = start


### PR DESCRIPTION
GHI : #382 

## Description:

Revert asking for collections when listing a library.

This is not necessary for the current collections management (through a filter but not merged into the movies list) and makes the library list miss as much movies as there are collections because of an out for range error (see my log in #382).

This also fixes #373, #354 and #344.

## Checklist:
- [X] I have based this PR against the develop branch
